### PR TITLE
Add Codex helper docs and setup script

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,31 @@
+# Codex Development Guide
+
+This repository contains the LibreAssistant application with a Python backend and a Tauri/Svelte frontend. When making changes with Codex or other tooling, follow the steps below so tests and lint checks pass consistently.
+
+## Setup
+
+Run `./setup.sh` once in a fresh environment to install Python and Node dependencies.
+
+## Formatting and Linting
+
+- Python code is formatted with **Black** and linted with **Ruff**.
+- Run these from the `backend` directory:
+  ```bash
+  black --check .
+  ruff .
+  ```
+
+## Testing
+
+- Backend tests use `pytest`:
+  ```bash
+  cd backend
+  python -m pytest
+  ```
+- Frontend type checking:
+  ```bash
+  cd ../frontend
+  npm run check
+  ```
+
+Always run the formatting, lint, and test commands before committing.

--- a/README.md
+++ b/README.md
@@ -148,16 +148,26 @@ git clone https://github.com/aubreyhayes47/LibreAssistant.git
 cd LibreAssistant
 ```
 
-### Frontend Setup
+### Quick Setup
+
+Install all Python and Node dependencies with the helper script:
+
+```
+./setup.sh
+```
+
+This creates a local virtual environment in `.venv/` and runs `npm install` in
+`frontend/`. Activate the environment with `source .venv/bin/activate` after the
+script finishes.
+
+### Manual Setup Steps
+
+If you prefer a manual approach you can still install each part individually:
 
 ```
 cd frontend
 npm install
-```
 
-### Backend Setup
-
-```
 cd ../backend
 python -m venv venv
 source venv/bin/activate

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -e
+
+# Create Python virtual environment if not present
+if [ ! -d ".venv" ]; then
+    python3 -m venv .venv
+fi
+source .venv/bin/activate
+
+pip install -r backend/requirements.txt
+
+# Install frontend dependencies
+pushd frontend >/dev/null
+npm install
+popd >/dev/null
+
+echo "Setup complete. Activate with 'source .venv/bin/activate'"


### PR DESCRIPTION
## Summary
- document development workflow in new AGENTS.md
- add setup.sh helper to install Python and Node dependencies
- mention setup script in README

## Testing
- `black --check .` *(fails: would reformat files)*
- `ruff check .` *(fails: found 114 errors)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*
- `npm run check` *(fails: `svelte-kit` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ca58207588332b2f884ee6be738db