### PR TITLE
Refine docs for single-user AI browser vision

### DIFF
--- a/.github/TROUBLESHOOTING_PLAN.md
+++ b/.github/TROUBLESHOOTING_PLAN.md
@@ -1,5 +1,7 @@
 # LibreAssistant Troubleshooting Plan - PHASE 1D DEVELOPMENT
 
+LibreAssistant aims to replace traditional web browsers with a single-user assistant that fetches and summarizes content for you. The project is privacy-first and runs locally with optional Ollama integration.
+
 **Date Updated**: July 9, 2025
 **Current Phase**: Phase 1D (Browser Integration)
 **Status**: 🚧 Phase 1D in progress - basic browser panel and summarization command implemented

--- a/.github/copilot-algorithm.md
+++ b/.github/copilot-algorithm.md
@@ -1,5 +1,7 @@
 # LibreAssistant Implementation Algorithm
 
+LibreAssistant is a privacy-first, single-user interface to the internet. It fetches and summarizes online content so users can read the web through an AI assistant.
+
 ## MVP-1: Core Chat + Browser Foundation
 
 ### PHASE 1A: Backend Infrastructure Setup
@@ -328,7 +330,8 @@
    c. Drag-and-drop content organization
    d. Keyboard shortcuts for all major functions
 
-2. Collaboration Features:
+2. Collaboration Features (Keystone Hub):
+   *These features may appear in a future server-hosted companion project. LibreAssistant itself remains single-user.*
    a. Share chat sessions and content
    b. Export conversations as reports
    c. Collaborative bookmarking

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -7,7 +7,7 @@ This is a Tauri-based AI assistant application with a Python backend for high-pe
 ## Project Identity
 
 - **Name**: LibreAssistant
-- **Purpose**: Open source AI assistant browser
+- **Purpose**: Privacy-first AI browser replacement
 - **Focus**: Privacy-first, local AI processing
 - **License**: MIT License
 

--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
 # 📜 LibreAssistant
 
-An open-source, privacy-first AI assistant platform built with Tauri, Svelte, Rust, and Python. Designed for **local-first AI**, **web automation**, and **customizable Flavors** that serve real communities—especially those most overlooked.
+An open-source, privacy-first browser replacement powered by Tauri, Svelte, Rust, and Python. LibreAssistant fetches and summarizes web content for you so you rarely need to open cluttered pages yourself. It is designed for **local-first AI**, **web automation**, and **customizable Flavors** that serve real communities—especially those most overlooked.
 
 ---
 
 ## ✝️ Mission
 
-LibreAssistant is more than a single app—it's a **flexible, modular platform** for building secure, local-first AI tools that *respect privacy* and *empower service*.
+LibreAssistant is your private, local-first AI gateway to the internet—an assistant that reads the web for you, summarizes what matters, and protects your privacy.
 
-Our goal is to support **families, churches, schools, clinics, nonprofits, and small businesses**—especially in low-resource or disconnected environments.
+Our focus is helping individuals and small organizations reclaim the web without sacrificing privacy or control.
 
 > *“Serve the least, the last, and the lost—locally and globally.”*
 
@@ -16,25 +16,27 @@ Our goal is to support **families, churches, schools, clinics, nonprofits, and s
 
 ## 🚀 Features
 
-✅ **Local AI Integration** with Ollama for private, on-device conversations
+✅ **Local AI Chat** with Ollama for private, on-device conversations
 
-✅ **Web Automation** with scraping and browser control
+✅ **Embedded Browser Panel** for optional page previews
 
-✅ **Modular Plugin System** for adding custom tools
+✅ **Web Scraping & Extraction** to pull clean text from sites
 
-✅ **Privacy First** with no mandatory cloud
+✅ **Summarization Pipeline** that returns concise answers
 
-✅ **Role-Based Access Control (RBAC)** for multi-user setups
+✅ **Search Agent** supporting multiple providers
 
-✅ **Flavor System** for audience-specific configurations
+✅ **Plugin System** for web-focused automation
 
-✅ **USB/SD Distribution** for offline use
+✅ **Flavor System** for single-user plugin bundles
+
+✅ **Optional USB/SD Distribution** for offline use
 
 ---
 
 ## 🌍 Example Flavors
 
-LibreAssistant is designed to be **configured** for specific audiences and use cases through "Flavors"—predefined bundles of plugins, UI layouts, and permissions.
+LibreAssistant is designed to be **configured** for specific audiences through "Flavors"—predefined bundles of plugins and UI layouts.
 
 ✅ Solo Private Assistant (Power User)
 
@@ -108,7 +110,6 @@ Each Flavor is defined by a **config file** (e.g. `flavor.json`):
 
 * Default plugins
 * UI layout and components
-* User roles and permissions
 * Localization and language settings
 
 Example `flavor.json`:
@@ -117,7 +118,6 @@ Example `flavor.json`:
 {
   "name": "Faith & Community Memphis Edition",
   "plugins": ["note_manager", "reading_plan", "consent_log", "phrasebook"],
-  "roles": ["Admin", "Guest"],
   "locale": "en-US"
 }
 ```
@@ -324,4 +324,4 @@ We aim to enable **ethical, local-first AI** that can be used anywhere—from su
 
 Please open an issue on GitHub or contact the development team.
 
-LibreAssistant — *Your privacy-first, modular AI assistant platform. Built with ❤️ and guided by the Beatitudes.*
+LibreAssistant — *Your privacy-first AI gateway to the internet. Built with ❤️ and guided by the Beatitudes.*

--- a/docs/PHASE_1D_PLAN.md
+++ b/docs/PHASE_1D_PLAN.md
@@ -1,6 +1,6 @@
 # Phase 1D Development Plan
 
-This document outlines the initial goals and tasks for Phase 1D of the LibreAssistant MVP. Phase 1D introduces an embedded browser panel and server-side page summarization.
+This document outlines the goals for Phase 1D of the LibreAssistant MVP. LibreAssistant is a single-user, privacy-first interface to the internet. Phase 1D expands the app with an embedded browser preview and automated page summarization so users can read the web through the assistant instead of a traditional browser.
 
 ## Goals
 
@@ -14,7 +14,11 @@ This document outlines the initial goals and tasks for Phase 1D of the LibreAssi
    - Reuse the existing `ContentExtractor` agent to fetch page text.
    - Generate an LLM summary and store it using `SummaryOperations`.
 
-3. **Tauri Integration**
+3. **Search Agent Preparation**
+   - Begin a search workflow that queries multiple providers.
+   - Feed search results into the summarization pipeline.
+
+4. **Tauri Integration**
    - Expose the `summarize_page` command from Rust and add it to the invoke handler list.
    - Wire the new command into the BrowserPanel component so users can request summaries.
 


### PR DESCRIPTION
## Summary
- update README with new mission statement and features
- clarify flavor configuration example
- update Phase 1D plan with search agent notes
- add vision notes to troubleshooting plan and algorithm
- tweak copilot instructions wording

## Testing
- `black --check .`
- `ruff check .`
- `python -m pytest`
- `npm run check`

------
https://chatgpt.com/codex/tasks/task_e_686cb045de288332aa231154a8dc848d