### PR TITLE
Align docs with single-user design

### DIFF
--- a/.github/TROUBLESHOOTING_PLAN.md
+++ b/.github/TROUBLESHOOTING_PLAN.md
@@ -1,6 +1,6 @@
 # LibreAssistant Troubleshooting Plan - PHASE 1D DEVELOPMENT
 
-LibreAssistant aims to replace traditional web browsers with a single-user assistant that fetches and summarizes content for you. The project is privacy-first and runs locally with optional Ollama integration.
+LibreAssistant is a privacy-first, single-user assistant that fetches and summarizes web content for you. It serves as an AI gateway to the internet and runs locally with optional Ollama integration.
 
 **Date Updated**: July 9, 2025
 **Current Phase**: Phase 1D (Browser Integration)
@@ -161,17 +161,17 @@ Initial browser integration is functional. Remaining tasks focus on UI polish an
 - **Security**: Local-first architecture working well
 - **Testing coverage**: Core functionality proven working
 
-## Next Steps - Phase 1D Development
+## Next Steps
 
-### IMMEDIATE (This Week)
-1. **Create BrowserPanel.svelte** for in-app browsing
-2. **Integrate content extraction agents**
-3. **Enable page summarization in chat**
+### Immediate Focus
+1. **Enhance content extraction** for dynamic sites
+2. **Tune summarization prompts** for concise answers
+3. **Integrate the search agent** with multiple providers
 
-### READY FOR PHASE 1D
-1. Implement navigation controls and bookmarking
-2. Connect extracted content to the existing database
-3. Polish UI and cross-platform testing
+### Upcoming Tasks
+1. Simplify plugin loading and remove multi-user hooks
+2. Improve local memory and user settings management
+3. Polish the optional browser panel and history syncing
 
 ### SUCCESS METRICS ACHIEVED
 - **Core Architecture**: 100% Complete ✅

--- a/.github/copilot-algorithm.md
+++ b/.github/copilot-algorithm.md
@@ -411,3 +411,25 @@ LibreAssistant is a privacy-first, single-user interface to the internet. It fet
 - [ ] Advanced features don't impact core performance
 
 This algorithm provides a systematic approach to building LibreAssistant with clear milestones, testing criteria, and success metrics for both MVP phases.
+
+## Next Steps
+
+The roadmap below prioritizes features that strengthen LibreAssistant as a single-user assistant to the web:
+
+1. **Improve Summarization & Extraction**
+   - Refine the content parser for difficult sites
+   - Tune prompts for shorter, higher-quality summaries
+2. **Search Agent Integration**
+   - Combine results from multiple providers
+   - Feed result pages into the summarization pipeline
+3. **Plugin System Simplification**
+   - Streamline plugin loading and configuration
+   - Remove legacy multi-user hooks
+4. **Memory & Personalization**
+   - Persist local preferences in `user_settings`
+   - Allow quick clearing of history and memory
+5. **Embedded Browser Polish**
+   - Keep the web view optional as a fallback viewer
+   - Ensure all automation remains privacy-first
+
+These steps replace earlier multi-user and RBAC goals, focusing entirely on a privacy-respecting, local-first experience.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -7,7 +7,7 @@ This is a Tauri-based AI assistant application with a Python backend for high-pe
 ## Project Identity
 
 - **Name**: LibreAssistant
-- **Purpose**: Privacy-first AI browser replacement
+- **Purpose**: Privacy-first, single-user AI interface to the internet
 - **Focus**: Privacy-first, local AI processing
 - **License**: MIT License
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # 📜 LibreAssistant
 
-An open-source, privacy-first browser replacement powered by Tauri, Svelte, Rust, and Python. LibreAssistant fetches and summarizes web content for you so you rarely need to open cluttered pages yourself. It is designed for **local-first AI**, **web automation**, and **customizable Flavors** that serve real communities—especially those most overlooked.
+An open-source, privacy-first interface to the internet powered by Tauri, Svelte, Rust, and Python. LibreAssistant fetches and summarizes web content so you rarely need to open cluttered pages yourself. It is designed for **local-first AI**, **web automation**, and **customizable Flavors** that serve real communities—especially those most overlooked.
 
 ---
 
@@ -30,7 +30,7 @@ Our focus is helping individuals and small organizations reclaim the web without
 
 ✅ **Flavor System** for single-user plugin bundles
 
-✅ **Optional USB/SD Distribution** for offline use
+✅ **Offline Distribution** via USB/SD (optional)
 
 ---
 
@@ -124,7 +124,7 @@ Example `flavor.json`:
 
 ✅ Fully offline
 
-✅ USB/SD deployable
+✅ USB/SD deployable (optional)
 
 ✅ Low-spec hardware friendly
 


### PR DESCRIPTION
## Summary
- clarify README intro and feature list
- adjust Copilot instructions to reference single-user usage
- add next steps roadmap and remove trailing text in algorithm document
- update troubleshooting plan with new priorities

## Testing
- `black --check .`
- `ruff check .`
- `python -m pytest`
- `npm install`
- `npm run check`

------
https://chatgpt.com/codex/tasks/task_e_686cb3298b208332815cdfab629a9bbd