### PR TITLE
Implement content analysis with LLM

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -383,19 +383,42 @@ class CommandHandler:
             return {"success": False, "error": f"Unknown data type: {data_type}"}
 
     async def analyze_content(self, payload: Dict[str, Any]) -> Dict[str, Any]:
-        """Legacy: Analyze content using LLM."""
+        """Analyze arbitrary content using the LLM."""
         content = payload.get("content")
         if not content:
             return {"success": False, "error": "No content provided"}
 
-        # TODO: Implement content analysis with new LLM infrastructure
-        return {
-            "success": True,
-            "analysis": "Content analysis will go here...",
-            "keywords": [],
-            "summary": "",
-            "message": "Legacy command - will be replaced with LLM analysis",
-        }
+        url = payload.get("url", "")
+        title = payload.get("title", "")
+
+        try:
+            prompt_builder = get_prompt_builder()
+            prompt = prompt_builder.build_bookmark_analysis_prompt(url, title, content)
+
+            client = await get_ollama_client()
+            llm_result = await client.chat_completion(
+                [
+                    {"role": "system", "content": prompt},
+                    {"role": "user", "content": content[:2000]},
+                ]
+            )
+
+            if llm_result["success"]:
+                analysis_text = llm_result["message"].get("content", "")
+                return {
+                    "success": True,
+                    "analysis": analysis_text,
+                    "model": llm_result.get("model"),
+                }
+            else:
+                return {
+                    "success": False,
+                    "error": llm_result.get("error", "LLM error"),
+                }
+
+        except Exception as e:
+            logger.error(f"Analyze content error: {str(e)}")
+            return {"success": False, "error": str(e)}
 
     async def summarize_page_command(self, payload: Dict[str, Any]) -> Dict[str, Any]:
         """Extract a URL and return an LLM summary."""

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -35,12 +35,16 @@ pytest-asyncio = "^0.21.0"
 line-length = 88
 target-version = ['py310']
 
+
 [tool.ruff]
+line-length = 88
+target-version = "py310"
+
+[tool.ruff.lint]
 select = ["E", "F", "I"]
 ignore = []
 fixable = ["A", "B", "C", "D", "E", "F", "I"]
 unfixable = []
-line-length = 88
 
 [tool.pytest.ini_options]
 asyncio_mode = "auto"

--- a/frontend/src/lib/BrowserPanel.svelte
+++ b/frontend/src/lib/BrowserPanel.svelte
@@ -38,10 +38,10 @@
 <div class="browser-panel">
   <div class="controls">
     <input bind:value={url} placeholder="Enter URL" />
-    <button on:click={navigate} disabled={isLoading}>Go</button>
-    <button on:click={summarize} disabled={isLoading}>Summarize</button>
+    <button onclick={navigate} disabled={isLoading}>Go</button>
+    <button onclick={summarize} disabled={isLoading}>Summarize</button>
   </div>
-  <iframe class="webview" src={iframeSrc}></iframe>
+  <iframe class="webview" src={iframeSrc} title="browser preview"></iframe>
   {#if summary}
     <div class="summary">
       <h3>Page Summary</h3>


### PR DESCRIPTION
## Summary
- update Ruff configuration for new syntax
- implement `analyze_content` command using the LLM
- fix accessibility and event warnings in `BrowserPanel.svelte`

## Testing
- `black --check .`
- `ruff check .`
- `python -m pytest`
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_686cba6f937c833299b34cffcdb89044