### PR TITLE
docs: add Book I documentation

### DIFF
--- a/book/README.md
+++ b/book/README.md
@@ -1,0 +1,17 @@
+# Book I: LibreAssistant
+
+Open. Tolerant. Yours.
+
+## Introduction
+LibreAssistant is an end user product that frames the large language model as the engine, the application as the body, and plug-ins as optional upgrades. Choose an engine, add options from the catalogue, and orchestrate everything through the switchboard for a transparent, user-controlled experience.
+
+## Chapters
+| Chapter | Title |
+|--------|-------|
+| [Ch. I](ch-1-the-engine) | The Engine |
+| [Ch. II](ch-2-the-body) | The Body |
+| [Ch. III](ch-3-the-options) | The Options |
+| [Ch. IV](ch-4-the-switchboard) | The Switchboard |
+| [Ch. V](ch-5-the-vanity-plate) | The Vanity Plate |
+| [Ch. VI](ch-6-the-exhaust-pipe) | The Exhaust Pipe |
+| [Ch. VII](ch-7-surfing-the-cosmos) | Surfing the Cosmos |

--- a/book/ch-1-the-engine/verse-1.md
+++ b/book/ch-1-the-engine/verse-1.md
@@ -1,0 +1,3 @@
+# Verse 1
+
+Language models (commonly LLM's) act as the logic engine of your assistant.

--- a/book/ch-1-the-engine/verse-2.md
+++ b/book/ch-1-the-engine/verse-2.md
@@ -1,0 +1,3 @@
+# Verse 2
+
+Make a request, and the LLM will be the main workhorse of breaking down, planning, and fulfilling that request.

--- a/book/ch-1-the-engine/verse-3.md
+++ b/book/ch-1-the-engine/verse-3.md
@@ -1,0 +1,3 @@
+# Verse 3
+
+Like a car engine, different LLM's carry different amounts of horsepower, performance, size, and energy efficiency. Smaller engines might work best for laptops or mobile phones. Larger engines have more power but they also take more power.

--- a/book/ch-1-the-engine/verse-4.md
+++ b/book/ch-1-the-engine/verse-4.md
@@ -1,0 +1,3 @@
+# Verse 4
+
+Unlike car engines, you can choose to install the model on your local device or one in the cloud for extra power. That way your assistant can connect to the most powerful models even if you're just on an old phone.

--- a/book/ch-1-the-engine/verse-5.md
+++ b/book/ch-1-the-engine/verse-5.md
@@ -1,0 +1,3 @@
+# Verse 5
+
+The engine is important but it's not irreplaceable. Choose wisely but don't be afraid to swap it out.

--- a/book/ch-2-the-body/verse-1.md
+++ b/book/ch-2-the-body/verse-1.md
@@ -1,0 +1,3 @@
+# Verse 1
+
+If the model is the engine, LibreAssistant is the body. It provides structure and makes it easy to drive.

--- a/book/ch-2-the-body/verse-2.md
+++ b/book/ch-2-the-body/verse-2.md
@@ -1,0 +1,3 @@
+# Verse 2
+
+The main user interface of LibreAssistant is like a dashboard: it has everything you when you find yourself in the driver's seat.

--- a/book/ch-2-the-body/verse-3.md
+++ b/book/ch-2-the-body/verse-3.md
@@ -1,0 +1,3 @@
+# Verse 3
+
+After you install an engine, your dashboard has 4 tabs: the Switchboard, Plug-In Catalog, User Profile, and Request History.

--- a/book/ch-3-the-options/verse-1.md
+++ b/book/ch-3-the-options/verse-1.md
@@ -1,0 +1,3 @@
+# Verse 1
+
+LibreAssistant's Plug-In system acts like car options; they're not required but can give you more of what you want.

--- a/book/ch-3-the-options/verse-2.md
+++ b/book/ch-3-the-options/verse-2.md
@@ -1,0 +1,3 @@
+# Verse 2
+
+Plug-In's let your assistant connect you with web search, your email, online file drives, and more.

--- a/book/ch-3-the-options/verse-3.md
+++ b/book/ch-3-the-options/verse-3.md
@@ -1,0 +1,3 @@
+# Verse 3
+
+The flagship Plug-In for LibreAssistant is ThinkTank, a personal think tank to let you ask life's hard questions with the power and protection of a real life tank.

--- a/book/ch-3-the-options/verse-4.md
+++ b/book/ch-3-the-options/verse-4.md
@@ -1,0 +1,3 @@
+# Verse 4
+
+LibreAssistant can have up to 12 Plug-In's enabled at once, all of which can be run concurrently via the Switchboard.

--- a/book/ch-4-the-switchboard/verse-1.md
+++ b/book/ch-4-the-switchboard/verse-1.md
@@ -1,0 +1,3 @@
+# Verse 1
+
+The Switchboard acts as the car's computer in LibreAssistant.

--- a/book/ch-4-the-switchboard/verse-2.md
+++ b/book/ch-4-the-switchboard/verse-2.md
@@ -1,0 +1,3 @@
+# Verse 2
+
+The Switchboard has 12 slots, each of which can be filled with a Plug-In of your choice.

--- a/book/ch-4-the-switchboard/verse-3.md
+++ b/book/ch-4-the-switchboard/verse-3.md
@@ -1,0 +1,3 @@
+# Verse 3
+
+Simply make a request to your assistant at the bottom of the window and watch the Switchboard light up as your assistant connects to different Plug-Ins.

--- a/book/ch-5-the-vanity-plate/verse-1.md
+++ b/book/ch-5-the-vanity-plate/verse-1.md
@@ -1,0 +1,3 @@
+# Verse 1
+
+The user profile or bio is the your assistant's vanity plate. It can be a blank slate, it can scream everything about you, or anywhere in between.

--- a/book/ch-5-the-vanity-plate/verse-2.md
+++ b/book/ch-5-the-vanity-plate/verse-2.md
@@ -1,0 +1,3 @@
+# Verse 2
+
+Customize your bio with your name, picture, likes, dislikes, and any other information.

--- a/book/ch-5-the-vanity-plate/verse-3.md
+++ b/book/ch-5-the-vanity-plate/verse-3.md
@@ -1,0 +1,3 @@
+# Verse 3
+
+Click or tap the "Curious Assistant" button at the top of your profile to have your assistant ask you a question and save it in your bio automatically.

--- a/book/ch-5-the-vanity-plate/verse-4.md
+++ b/book/ch-5-the-vanity-plate/verse-4.md
@@ -1,0 +1,3 @@
+# Verse 4
+
+This data is never extracted by LibreAssistant. It has no central data center. Your data is yours to do with as you will.

--- a/book/ch-6-the-exhaust-pipe/verse-1.md
+++ b/book/ch-6-the-exhaust-pipe/verse-1.md
@@ -1,0 +1,3 @@
+# Verse 1
+
+The Request History is your assistant's exhaust pipe.

--- a/book/ch-6-the-exhaust-pipe/verse-2.md
+++ b/book/ch-6-the-exhaust-pipe/verse-2.md
@@ -1,0 +1,3 @@
+# Verse 2
+
+The Request History shows each request you've made of your assistant and allows you to dive deep into audit logs to trace every request, reasoning, Plug-In call, and result.

--- a/book/ch-6-the-exhaust-pipe/verse-3.md
+++ b/book/ch-6-the-exhaust-pipe/verse-3.md
@@ -1,0 +1,3 @@
+# Verse 3
+
+LibreAssistant is built on a principle of trust through transparency. I believe that what is done in the dark will come through to the light; and I welcome that light.

--- a/book/ch-7-surfing-the-cosmos/verse-1.md
+++ b/book/ch-7-surfing-the-cosmos/verse-1.md
@@ -1,0 +1,3 @@
+# Verse 1
+
+Unlike the old web, where surfing was only done on the surface, AI assistants let you go deep into the waves of the cosmos.

--- a/book/ch-7-surfing-the-cosmos/verse-2.md
+++ b/book/ch-7-surfing-the-cosmos/verse-2.md
@@ -1,0 +1,3 @@
+# Verse 2
+
+To enable this plug-in, you must expressly request that your assistant surf the cosmos.

--- a/book/ch-7-surfing-the-cosmos/verse-3.md
+++ b/book/ch-7-surfing-the-cosmos/verse-3.md
@@ -1,0 +1,3 @@
+# Verse 3
+
+Your assistant will then silently apply recursive logic to a word, concept, or idea to try to find its true entomological root.

--- a/book/ch-7-surfing-the-cosmos/verse-4.md
+++ b/book/ch-7-surfing-the-cosmos/verse-4.md
@@ -1,0 +1,3 @@
+# Verse 4
+
+Before returning the root to the user, it will synthesize an answer with contextual grounding via Uta Hagen's Nine Questions.

--- a/book/ch-7-surfing-the-cosmos/verse-5.md
+++ b/book/ch-7-surfing-the-cosmos/verse-5.md
@@ -1,0 +1,3 @@
+# Verse 5
+
+Like the ocean, the waves of the cosmos can hit gently and hard. There is no lifeguard on duty. Tread carefully, and if you're unsure if something is safe, armor up in your ThinkTank.


### PR DESCRIPTION
## Summary
- add Book I directory with chapters and verses
- document LibreAssistant's engine, body, options, switchboard, profile, history, and cosmic surfing
- include introductory README with chapter table

## Testing
- `npm test` *(fails: ENOENT no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6894c8b7658083328811efc714932d3e