### PR TITLE
feat: add echo plugin

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,16 @@
+# Copyright (c) 2024 LibreAssistant contributors.
+# Licensed under the MIT License.
+
+__pycache__
+*.pyc
+*.pyo
+*.pyd
+build
+dist
+.git
+.gitignore
+.mypy_cache
+.pytest_cache
+venv
+.venv
+.env

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,30 +8,17 @@ on:
     branches: [develop]
 
 jobs:
-  tests:
+  checks:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v4
         with:
           python-version: '3.x'
-      - run: pip install pytest
-      - run: pytest
-
-  markdown:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
+      - run: pip install '.[development]'
+      - run: pytest --cov=src/libreassistant
+      - run: python scripts/check_license_headers.py
       - uses: actions/setup-node@v4
         with:
           node-version: '18'
-      - run: npx markdownlint-cli '**/*.md'
-
-  license:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v4
-        with:
-          python-version: '3.x'
-      - run: python scripts/check_license_headers.py
+      - run: npx --yes markdownlint-cli '**/*.md'

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -14,7 +14,6 @@ Examples of behavior that contributes to a positive environment include:
 - Focusing on what is best for the community
 - Showing tolerance toward other community members
 
-
 ## Enforcement Responsibilities
 Project maintainers are responsible for clarifying and enforcing standards of acceptable behavior.  The maintainers may remove, edit, or reject contributions that are not aligned with this Code of Conduct.
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+# Copyright (c) 2024 LibreAssistant contributors.
+# Licensed under the MIT License.
+
+# Base image
+FROM python:3.10-slim
+
+# Set working directory
+WORKDIR /app
+
+# Copy project and install runtime dependencies
+COPY . /app
+RUN pip install --no-cache-dir .
+
+# Default command
+CMD ["python", "-m", "libreassistant"]

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,0 +1,13 @@
+# Copyright (c) 2024 LibreAssistant contributors.
+# Licensed under the MIT License.
+
+# Development image with hot reload
+FROM python:3.10-slim
+
+WORKDIR /app
+
+# Copy project and install with development dependencies in editable mode
+COPY . /app
+RUN pip install --no-cache-dir -e .[dev]
+
+CMD ["uvicorn", "libreassistant.main:app", "--host", "0.0.0.0", "--port", "8000", "--reload"]

--- a/README.md
+++ b/README.md
@@ -4,3 +4,19 @@
 A FOSS alternative to next-gen AI assistants like Google Gemini and ChatGPT.
 
 Continuous integration runs tests, Markdown style checks, and license header verification on every pull request.
+
+## Development
+
+A Docker-based environment is provided for local development. Start the API with:
+
+```sh
+docker compose up --build
+```
+
+The service will be available at [http://localhost:8000](http://localhost:8000).
+
+## Plugins
+
+LibreAssistant ships with a simple `echo` plugin that returns the provided message and stores it in the user's state. It serves as a reference implementation for developing additional plugins.
+
+See [docs/plugin-api.md](docs/plugin-api.md) for details on writing and registering plugins.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,14 @@
+# Copyright (c) 2024 LibreAssistant contributors.
+# Licensed under the MIT License.
+
+version: "3.9"
+
+services:
+  app:
+    build:
+      context: .
+      dockerfile: Dockerfile.dev
+    volumes:
+      - .:/app
+    ports:
+      - "8000:8000"

--- a/docs/plugin-api.md
+++ b/docs/plugin-api.md
@@ -1,0 +1,57 @@
+<!-- Copyright (c) 2024 LibreAssistant contributors. Licensed under the MIT License. -->
+
+# Plugin API
+
+Plugins extend LibreAssistant by implementing custom behavior that can be invoked through the microkernel.
+
+## Plugin Interface
+
+A plugin is any object that provides a `run` method with the following signature:
+
+```python
+from typing import Any, Dict
+
+def run(self, user_state: Dict[str, Any], payload: Dict[str, Any]) -> Dict[str, Any]:
+    """Execute the plugin logic."""
+    ...
+```
+
+- `user_state` is a mutable dictionary persisted for each user. Plugins may read or modify this dictionary to maintain state between invocations.
+- `payload` contains the arguments supplied by the caller.
+- The return value is a dictionary that becomes the plugin's response.
+
+## Registration
+
+Plugins must be registered with the microkernel before they can be invoked. Registration associates a plugin instance with a unique name:
+
+```python
+from libreassistant.kernel import kernel
+
+class MyPlugin:
+    def run(self, user_state, payload):
+        ...
+
+kernel.register_plugin("my-plugin", MyPlugin())
+```
+
+Built-in plugins may expose a helper function to encapsulate registration.
+
+## Example
+
+The built-in `echo` plugin returns the provided message and stores it in the user's state:
+
+```python
+from typing import Any, Dict
+from libreassistant.kernel import kernel
+
+class EchoPlugin:
+    def run(self, user_state: Dict[str, Any], payload: Dict[str, Any]) -> Dict[str, Any]:
+        message = payload.get("message", "")
+        user_state["last_message"] = message
+        return {"echo": message}
+
+def register() -> None:
+    kernel.register_plugin("echo", EchoPlugin())
+```
+
+The plugin can then be invoked through the `/api/v1/invoke` endpoint by specifying its name and a payload.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,33 @@
+# Copyright (c) 2024 LibreAssistant contributors.
+# Licensed under the MIT License.
+
+[build-system]
+requires = ["setuptools>=61"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "libreassistant"
+version = "0.1.0"
+description = "LibreAssistant microkernel application"
+readme = "README.md"
+requires-python = ">=3.10"
+license = {text = "MIT"}
+authors = [{name = "LibreAssistant contributors"}]
+dependencies = [
+    "fastapi",
+    "uvicorn",
+]
+
+[project.optional-dependencies]
+dev = [
+    "pytest",
+    "pytest-cov",
+    "httpx",
+]
+
+[tool.setuptools.packages.find]
+where = ["src"]
+
+[tool.setuptools]
+package-dir = {"" = "src"}
+

--- a/src/libreassistant/__init__.py
+++ b/src/libreassistant/__init__.py
@@ -1,0 +1,10 @@
+# Copyright (c) 2024 LibreAssistant contributors.
+# Licensed under the MIT License.
+
+"""Core package for the LibreAssistant application."""
+
+from .kernel import kernel
+
+__all__ = ["__version__", "kernel"]
+
+__version__ = "0.1.0"

--- a/src/libreassistant/__main__.py
+++ b/src/libreassistant/__main__.py
@@ -1,0 +1,17 @@
+# Copyright (c) 2024 LibreAssistant contributors.
+# Licensed under the MIT License.
+
+"""Run the LibreAssistant application with Uvicorn."""
+
+import uvicorn
+
+from .main import app
+
+
+def main() -> None:
+    """Run the Uvicorn development server."""
+    uvicorn.run(app, host="0.0.0.0", port=8000)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/libreassistant/kernel.py
+++ b/src/libreassistant/kernel.py
@@ -1,0 +1,47 @@
+# Copyright (c) 2024 LibreAssistant contributors.
+# Licensed under the MIT License.
+
+"""Minimal microkernel managing plugins and user state."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Protocol
+
+
+class Plugin(Protocol):
+    """Protocol that all plugins must implement."""
+
+    def run(self, user_state: Dict[str, Any], payload: Dict[str, Any]) -> Dict[str, Any]:
+        """Execute the plugin with the given user state and payload."""
+
+
+class Microkernel:
+    """Core microkernel responsible for plugin coordination."""
+
+    def __init__(self) -> None:
+        self._plugins: Dict[str, Plugin] = {}
+        self._states: Dict[str, Dict[str, Any]] = {}
+
+    def register_plugin(self, name: str, plugin: Plugin) -> None:
+        """Register a plugin implementation under a specific name."""
+        self._plugins[name] = plugin
+
+    def get_state(self, user_id: str) -> Dict[str, Any]:
+        """Retrieve mutable state for a user, creating it if necessary."""
+        return self._states.setdefault(user_id, {})
+
+    def invoke(self, name: str, user_id: str, payload: Dict[str, Any]) -> Dict[str, Any]:
+        """Invoke a registered plugin for the given user."""
+        plugin = self._plugins.get(name)
+        if plugin is None:
+            raise KeyError(name)
+        state = self.get_state(user_id)
+        return plugin.run(state, payload)
+
+    def reset(self) -> None:
+        """Reset the registry and user state store. Intended for tests."""
+        self._plugins.clear()
+        self._states.clear()
+
+
+kernel = Microkernel()

--- a/src/libreassistant/main.py
+++ b/src/libreassistant/main.py
@@ -1,0 +1,44 @@
+# Copyright (c) 2024 LibreAssistant contributors.
+# Licensed under the MIT License.
+
+"""Application entrypoints and FastAPI app factory."""
+
+from typing import Any, Dict
+
+from fastapi import FastAPI, HTTPException
+from pydantic import BaseModel
+
+from .kernel import kernel
+from .plugins import echo
+
+
+def create_app() -> FastAPI:
+    """Create and configure the FastAPI application."""
+    app = FastAPI(title="LibreAssistant")
+
+    # Register built-in plugins
+    echo.register()
+
+    @app.get("/")
+    def read_root() -> Dict[str, str]:
+        return {"message": "LibreAssistant API"}
+
+    class InvokeRequest(BaseModel):
+        plugin: str
+        payload: Dict[str, Any]
+        user_id: str
+
+    @app.post("/api/v1/invoke")
+    def invoke(request: InvokeRequest) -> Dict[str, Any]:
+        """Invoke a registered plugin through the microkernel."""
+        try:
+            result = kernel.invoke(request.plugin, request.user_id, request.payload)
+        except KeyError as exc:  # pragma: no cover - error branch
+            raise HTTPException(status_code=404, detail="Plugin not found") from exc
+        state = kernel.get_state(request.user_id)
+        return {"result": result, "state": state}
+
+    return app
+
+
+app = create_app()

--- a/src/libreassistant/plugins/__init__.py
+++ b/src/libreassistant/plugins/__init__.py
@@ -1,0 +1,9 @@
+# Copyright (c) 2024 LibreAssistant contributors.
+# Licensed under the MIT License.
+
+"""Built-in plugins for LibreAssistant."""
+
+# Re-export registration functions for built-in plugins
+from .echo import register as register_echo
+
+__all__ = ["register_echo"]

--- a/src/libreassistant/plugins/echo.py
+++ b/src/libreassistant/plugins/echo.py
@@ -1,0 +1,24 @@
+# Copyright (c) 2024 LibreAssistant contributors.
+# Licensed under the MIT License.
+
+"""Simple echo plugin used as a reference implementation."""
+
+from __future__ import annotations
+
+from typing import Any, Dict
+
+from ..kernel import kernel
+
+
+class EchoPlugin:
+    """Echo back a message while updating user state."""
+
+    def run(self, user_state: Dict[str, Any], payload: Dict[str, Any]) -> Dict[str, Any]:
+        message = payload.get("message", "")
+        user_state["last_message"] = message
+        return {"echo": message}
+
+
+def register() -> None:
+    """Register the echo plugin with the microkernel."""
+    kernel.register_plugin("echo", EchoPlugin())

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,35 @@
+# Copyright (c) 2024 LibreAssistant contributors.
+# Licensed under the MIT License.
+
+"""Test configuration and fixtures."""
+
+from __future__ import annotations
+
+import pathlib
+import sys
+from typing import Generator
+
+import pytest
+from fastapi.testclient import TestClient
+
+# Add the src directory to the Python path to import the package without installation
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1] / "src"))
+
+from libreassistant.main import app  # noqa: E402  # isort:skip
+from libreassistant.kernel import kernel  # noqa: E402  # isort:skip
+from libreassistant.plugins.echo import register as register_echo  # noqa: E402  # isort:skip
+
+
+@pytest.fixture
+def client() -> Generator[TestClient, None, None]:
+    """Provide a TestClient for the FastAPI app."""
+    with TestClient(app) as client:
+        yield client
+
+
+@pytest.fixture(autouse=True)
+def reset_kernel() -> Generator[None, None, None]:
+    """Reset the microkernel between tests."""
+    kernel.reset()
+    register_echo()
+    yield

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,27 @@
+# Copyright (c) 2024 LibreAssistant contributors.
+# Licensed under the MIT License.
+
+"""Tests for the module entrypoint executed as a script."""
+
+from __future__ import annotations
+
+import runpy
+
+import uvicorn
+
+from libreassistant.main import app
+
+
+def test_module_main_invokes_uvicorn(monkeypatch) -> None:
+    """Running the module should call ``uvicorn.run`` with the app."""
+
+    called = {}
+
+    def fake_run(app_, host, port):
+        called.update({"app": app_, "host": host, "port": port})
+
+    monkeypatch.setattr(uvicorn, "run", fake_run)
+
+    runpy.run_module("libreassistant.__main__", run_name="__main__")
+
+    assert called == {"app": app, "host": "0.0.0.0", "port": 8000}

--- a/tests/test_echo_plugin.py
+++ b/tests/test_echo_plugin.py
@@ -1,0 +1,19 @@
+# Copyright (c) 2024 LibreAssistant contributors.
+# Licensed under the MIT License.
+
+"""Integration test for the built-in echo plugin."""
+
+from __future__ import annotations
+
+
+def test_echo_plugin_integration(client) -> None:
+    response = client.post(
+        "/api/v1/invoke",
+        json={"plugin": "echo", "payload": {"message": "hi"}, "user_id": "alice"},
+    )
+    assert response.status_code == 200
+    assert response.json() == {
+        "result": {"echo": "hi"},
+        "state": {"last_message": "hi"},
+    }
+

--- a/tests/test_kernel.py
+++ b/tests/test_kernel.py
@@ -1,0 +1,51 @@
+# Copyright (c) 2024 LibreAssistant contributors.
+# Licensed under the MIT License.
+
+"""Unit tests for the Microkernel core components."""
+
+from __future__ import annotations
+
+import pytest
+
+from libreassistant.kernel import Microkernel
+
+
+class EchoPlugin:
+    """Simple plugin used for testing."""
+
+    def run(self, state, payload):
+        state["echo"] = payload["msg"]
+        return {"echo": payload["msg"]}
+
+
+def test_register_and_invoke_updates_state() -> None:
+    kernel = Microkernel()
+    kernel.register_plugin("echo", EchoPlugin())
+    result = kernel.invoke("echo", "user", {"msg": "hi"})
+    assert result == {"echo": "hi"}
+    assert kernel.get_state("user") == {"echo": "hi"}
+
+
+def test_get_state_returns_same_dict() -> None:
+    kernel = Microkernel()
+    first = kernel.get_state("alice")
+    first["x"] = 1
+    second = kernel.get_state("alice")
+    assert first is second
+    assert second["x"] == 1
+
+
+def test_invoke_missing_plugin_raises() -> None:
+    kernel = Microkernel()
+    with pytest.raises(KeyError):
+        kernel.invoke("missing", "user", {})
+
+
+def test_reset_clears_plugins_and_state() -> None:
+    kernel = Microkernel()
+    kernel.register_plugin("echo", EchoPlugin())
+    kernel.invoke("echo", "user", {"msg": "hi"})
+    kernel.reset()
+    assert kernel.get_state("user") == {}
+    with pytest.raises(KeyError):
+        kernel.invoke("echo", "user", {"msg": "hi"})

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,0 +1,33 @@
+# Copyright (c) 2024 LibreAssistant contributors.
+# Licensed under the MIT License.
+
+"""Tests for the FastAPI application and microkernel endpoint."""
+
+from __future__ import annotations
+
+from libreassistant.kernel import kernel
+
+
+def test_read_root(client) -> None:
+    response = client.get("/")
+    assert response.status_code == 200
+    assert response.json() == {"message": "LibreAssistant API"}
+
+
+def test_user_state_persists(client) -> None:
+    class CounterPlugin:
+        def run(self, state, payload):
+            state["count"] = state.get("count", 0) + 1
+            return {"count": state["count"]}
+
+    kernel.register_plugin("counter", CounterPlugin())
+    first = client.post(
+        "/api/v1/invoke", json={"plugin": "counter", "payload": {}, "user_id": "bob"}
+    )
+    second = client.post(
+        "/api/v1/invoke", json={"plugin": "counter", "payload": {}, "user_id": "bob"}
+    )
+    assert first.json()["result"] == {"count": 1}
+    assert second.json()["result"] == {"count": 2}
+    assert second.json()["state"] == {"count": 2}
+


### PR DESCRIPTION
## Summary
- implement minimal microkernel with plugin registry and per-user state
- add built-in echo plugin with integration test and plugin API docs
- rename optional development dependency group to `dev` and update Dockerfile

## Testing
- `pytest --cov=src/libreassistant`
- `python scripts/check_license_headers.py`
- `npx --yes markdownlint-cli '**/*.md'` (warns about unknown `http-proxy` env config)


------
https://chatgpt.com/codex/tasks/task_e_6898f60b9a7c8332a07808d9808eec99