### PR TITLE
feat: add transparency dashboards

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,16 @@ A FOSS alternative to next-gen AI assistants like Google Gemini and ChatGPT.
 
 Continuous integration runs tests, Markdown style checks, and license header verification on every pull request.
 
+## Features
+
+- **Design System** – CSS design tokens and accessible web components (primary button, input field, information card, modal dialog)
+- **Main UI** – a tabbed layout with sections for Switchboard, Catalogue, Past Requests, and User Profile plus a six‑step onboarding flow
+- **Switchboard & Providers** – request composer with twelve plugin slots, provider registry for cloud or local models, and an initial system prompt
+- **Plugin Catalogue** – searchable list with enable/disable toggles
+- **Past Requests** – history API and `<la-past-requests>` component to review plugin interactions
+- **Personal Data Vault** – encrypted, consent-aware storage with export and deletion endpoints
+- **Transparency Dashboards** – Bill of Materials and System Health endpoints with corresponding web components
+
 ## Development
 
 A Docker-based environment is provided for local development. Start the API with:
@@ -14,6 +24,13 @@ docker compose up --build
 ```
 
 The service will be available at [http://localhost:8000](http://localhost:8000).
+
+Install dependencies and run the test suite with:
+
+```sh
+python -m pip install -e .[dev]
+pytest
+```
 
 ## Plugins
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,0 +1,27 @@
+<!-- Copyright (c) 2024 LibreAssistant contributors. Licensed under the MIT License. -->
+
+# API Overview
+
+LibreAssistant exposes a FastAPI service with endpoints for plugin invocation, user data management, provider integration, and transparency dashboards.
+
+## Invocation
+- `POST /api/v1/invoke` – invoke a registered plugin
+
+## History
+- `GET /api/v1/history/{user_id}` – return a user's past plugin invocations
+
+## Personal Data Vault
+- `POST /api/v1/vault/{user_id}` – store data
+- `GET /api/v1/vault/{user_id}` – retrieve stored data
+- `GET /api/v1/vault/{user_id}/export` – export stored data
+- `DELETE /api/v1/vault/{user_id}` – delete stored data
+- `POST /api/v1/consent/{user_id}` – set consent flag
+- `GET /api/v1/consent/{user_id}` – get consent status
+
+## Provider Integration
+- `POST /api/v1/providers/{name}/key` – configure an API key for a provider
+- `POST /api/v1/generate` – generate a response using the specified provider
+
+## Transparency
+- `GET /api/v1/bom` – list application dependencies and versions
+- `GET /api/v1/health` – expose request counts and runtime metrics

--- a/docs/plugin-api.md
+++ b/docs/plugin-api.md
@@ -55,3 +55,7 @@ def register() -> None:
 ```
 
 The plugin can then be invoked through the `/api/v1/invoke` endpoint by specifying its name and a payload.
+
+## History
+
+Each invocation is appended to a per-user log that can be retrieved via `GET /api/v1/history/{user_id}`. This history powers the Past Requests tab in the web UI and can aid debugging during plugin development.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ authors = [{name = "LibreAssistant contributors"}]
 dependencies = [
     "fastapi",
     "uvicorn",
+    "cryptography",
 ]
 
 [project.optional-dependencies]

--- a/src/libreassistant/main.py
+++ b/src/libreassistant/main.py
@@ -5,19 +5,37 @@
 
 from typing import Any, Dict
 
-from fastapi import FastAPI, HTTPException
+from fastapi import FastAPI, HTTPException, Request
 from pydantic import BaseModel
 
 from .kernel import kernel
 from .plugins import echo
+from .providers import providers
+from .providers.cloud import CloudProvider
+from .providers.local import LocalProvider
+from .vault import DataVault
+from .transparency import HealthMonitor, get_bill_of_materials
 
 
 def create_app() -> FastAPI:
     """Create and configure the FastAPI application."""
     app = FastAPI(title="LibreAssistant")
 
+    monitor = HealthMonitor()
+
+    @app.middleware("http")
+    async def record_metrics(request: Request, call_next):
+        monitor.record_request()
+        return await call_next(request)
+
     # Register built-in plugins
     echo.register()
+
+    # Register default providers
+    providers.register("cloud", CloudProvider())
+    providers.register("local", LocalProvider())
+
+    vault = DataVault()
 
     @app.get("/")
     def read_root() -> Dict[str, str]:
@@ -36,7 +54,80 @@ def create_app() -> FastAPI:
         except KeyError as exc:  # pragma: no cover - error branch
             raise HTTPException(status_code=404, detail="Plugin not found") from exc
         state = kernel.get_state(request.user_id)
+        history = state.setdefault("history", [])
+        history.append({"plugin": request.plugin, "payload": request.payload})
         return {"result": result, "state": state}
+
+    @app.get("/api/v1/history/{user_id}")
+    def get_history(user_id: str) -> Dict[str, Any]:
+        """Retrieve a user's past plugin invocations."""
+        state = kernel.get_state(user_id)
+        return {"history": state.get("history", [])}
+
+    class VaultData(BaseModel):
+        data: Dict[str, Any]
+
+    @app.post("/api/v1/vault/{user_id}")
+    def store_data(user_id: str, request: VaultData) -> Dict[str, str]:
+        vault.store(user_id, request.data)
+        return {"status": "ok"}
+
+    @app.get("/api/v1/vault/{user_id}")
+    def get_data(user_id: str) -> Dict[str, Any]:
+        return {"data": vault.retrieve(user_id)}
+
+    @app.get("/api/v1/vault/{user_id}/export")
+    def export_data(user_id: str) -> Dict[str, Any]:
+        return {"data": vault.export(user_id)}
+
+    @app.delete("/api/v1/vault/{user_id}")
+    def delete_data(user_id: str) -> Dict[str, str]:
+        vault.delete(user_id)
+        return {"status": "deleted"}
+
+    class Consent(BaseModel):
+        consent: bool
+
+    @app.post("/api/v1/consent/{user_id}")
+    def set_consent(user_id: str, request: Consent) -> Dict[str, str]:
+        vault.set_consent(user_id, request.consent)
+        return {"status": "ok"}
+
+    @app.get("/api/v1/consent/{user_id}")
+    def get_consent(user_id: str) -> Dict[str, bool]:
+        return {"consent": vault.get_consent(user_id)}
+
+    class ProviderKey(BaseModel):
+        key: str
+
+    @app.post("/api/v1/providers/{name}/key")
+    def set_provider_key(name: str, request: ProviderKey) -> Dict[str, str]:
+        providers.set_api_key(name, request.key)
+        return {"status": "ok"}
+
+    class GenerateRequest(BaseModel):
+        provider: str
+        prompt: str
+
+    @app.post("/api/v1/generate")
+    def generate(request: GenerateRequest) -> Dict[str, str]:
+        try:
+            result = providers.generate(request.provider, request.prompt)
+        except KeyError as exc:  # pragma: no cover - error branch
+            raise HTTPException(status_code=404, detail="Provider not found") from exc
+        except ValueError as exc:  # pragma: no cover - error branch
+            raise HTTPException(status_code=400, detail=str(exc)) from exc
+        return {"result": result}
+
+    @app.get("/api/v1/bom")
+    def get_bom() -> Dict[str, Any]:
+        """Return the application's Bill of Materials."""
+        return get_bill_of_materials()
+
+    @app.get("/api/v1/health")
+    def health() -> Dict[str, Any]:
+        """Expose basic system health metrics."""
+        return monitor.get_status()
 
     return app
 

--- a/src/libreassistant/prompt.py
+++ b/src/libreassistant/prompt.py
@@ -1,0 +1,10 @@
+# Copyright (c) 2024 LibreAssistant contributors.
+# Licensed under the MIT License.
+
+"""Expose the initial system prompt used by the application."""
+
+from __future__ import annotations
+
+from importlib import resources
+
+SYSTEM_PROMPT = resources.files("libreassistant").joinpath("system_prompt.txt").read_text()

--- a/src/libreassistant/providers/__init__.py
+++ b/src/libreassistant/providers/__init__.py
@@ -1,0 +1,47 @@
+# Copyright (c) 2024 LibreAssistant contributors.
+# Licensed under the MIT License.
+
+"""Simple provider abstraction and registry for AI backends."""
+
+from __future__ import annotations
+
+from typing import Dict, Protocol
+
+
+class Provider(Protocol):
+    """Protocol defining an AI provider."""
+
+    def generate(self, prompt: str, api_key: str | None = None) -> str:
+        """Generate a response for the given prompt."""
+
+
+class ProviderManager:
+    """Registry managing provider implementations and API keys."""
+
+    def __init__(self) -> None:
+        self._providers: Dict[str, Provider] = {}
+        self._api_keys: Dict[str, str] = {}
+
+    def register(self, name: str, provider: Provider) -> None:
+        """Register a provider implementation."""
+        self._providers[name] = provider
+
+    def set_api_key(self, name: str, key: str) -> None:
+        """Store the API key for a provider."""
+        self._api_keys[name] = key
+
+    def generate(self, name: str, prompt: str) -> str:
+        """Generate a response using the named provider."""
+        provider = self._providers.get(name)
+        if provider is None:
+            raise KeyError(name)
+        key = self._api_keys.get(name)
+        return provider.generate(prompt, key)
+
+    def reset(self) -> None:
+        """Reset the registry and stored API keys. Intended for tests."""
+        self._providers.clear()
+        self._api_keys.clear()
+
+
+providers = ProviderManager()

--- a/src/libreassistant/providers/cloud.py
+++ b/src/libreassistant/providers/cloud.py
@@ -1,0 +1,15 @@
+# Copyright (c) 2024 LibreAssistant contributors.
+# Licensed under the MIT License.
+
+"""Placeholder implementation of a cloud AI provider."""
+
+from __future__ import annotations
+
+
+class CloudProvider:
+    """Cloud-based provider that requires an API key."""
+
+    def generate(self, prompt: str, api_key: str | None = None) -> str:
+        if not api_key:
+            raise ValueError("API key required")
+        return f"cloud:{prompt}"

--- a/src/libreassistant/providers/local.py
+++ b/src/libreassistant/providers/local.py
@@ -1,0 +1,13 @@
+# Copyright (c) 2024 LibreAssistant contributors.
+# Licensed under the MIT License.
+
+"""Placeholder implementation of a local AI provider."""
+
+from __future__ import annotations
+
+
+class LocalProvider:
+    """Local provider that does not require an API key."""
+
+    def generate(self, prompt: str, api_key: str | None = None) -> str:
+        return f"local:{prompt}"

--- a/src/libreassistant/system_prompt.txt
+++ b/src/libreassistant/system_prompt.txt
@@ -1,0 +1,5 @@
+You are LibreAssistant, an open assistant that upholds the following principles:
+- Respect user autonomy and obtain explicit consent before using data.
+- Maintain privacy and minimize data collection.
+- Provide fair, balanced information without discrimination.
+- Act transparently so users can audit your behaviour.

--- a/src/libreassistant/transparency.py
+++ b/src/libreassistant/transparency.py
@@ -1,0 +1,41 @@
+# Copyright (c) 2024 LibreAssistant contributors.
+# Licensed under the MIT License.
+
+"""Transparency utilities for Bill of Materials and system health."""
+
+from __future__ import annotations
+
+import time
+from typing import Any, Dict, List
+
+import importlib.metadata
+
+
+class HealthMonitor:
+    """Simple in-memory tracker for system health metrics."""
+
+    def __init__(self) -> None:
+        self.start_time = time.time()
+        self.requests = 0
+        self.errors: List[str] = []
+
+    def record_request(self) -> None:
+        """Increment the total request count."""
+        self.requests += 1
+
+    def get_status(self) -> Dict[str, Any]:
+        """Return a snapshot of current system health metrics."""
+        return {
+            "status": "ok",
+            "uptime": time.time() - self.start_time,
+            "requests": self.requests,
+            "errors": self.errors,
+        }
+
+
+def get_bill_of_materials() -> Dict[str, List[str]]:
+    """Gather a list of installed dependencies, models, and datasets."""
+    dependencies = sorted(
+        f"{dist.metadata['Name']}=={dist.version}" for dist in importlib.metadata.distributions()
+    )
+    return {"dependencies": dependencies, "models": [], "datasets": []}

--- a/src/libreassistant/vault.py
+++ b/src/libreassistant/vault.py
@@ -1,0 +1,41 @@
+"""Encrypted in-memory data vault for user data."""
+from __future__ import annotations
+
+import json
+from typing import Any, Dict
+
+from cryptography.fernet import Fernet
+
+
+class DataVault:
+    """Store user data encrypted with a symmetric key."""
+
+    def __init__(self, key: bytes | None = None) -> None:
+        self._fernet = Fernet(key or Fernet.generate_key())
+        self._data: Dict[str, bytes] = {}
+        self._consent: Dict[str, bool] = {}
+
+    def store(self, user_id: str, data: Dict[str, Any]) -> None:
+        payload = json.dumps(data).encode()
+        token = self._fernet.encrypt(payload)
+        self._data[user_id] = token
+
+    def retrieve(self, user_id: str) -> Dict[str, Any]:
+        token = self._data.get(user_id)
+        if not token:
+            return {}
+        payload = self._fernet.decrypt(token)
+        return json.loads(payload.decode())
+
+    def delete(self, user_id: str) -> None:
+        self._data.pop(user_id, None)
+        self._consent.pop(user_id, None)
+
+    def export(self, user_id: str) -> Dict[str, Any]:
+        return self.retrieve(user_id)
+
+    def set_consent(self, user_id: str, consent: bool) -> None:
+        self._consent[user_id] = consent
+
+    def get_consent(self, user_id: str) -> bool:
+        return self._consent.get(user_id, False)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -18,6 +18,9 @@ sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1] / "src"))
 from libreassistant.main import app  # noqa: E402  # isort:skip
 from libreassistant.kernel import kernel  # noqa: E402  # isort:skip
 from libreassistant.plugins.echo import register as register_echo  # noqa: E402  # isort:skip
+from libreassistant.providers import providers  # noqa: E402  # isort:skip
+from libreassistant.providers.cloud import CloudProvider  # noqa: E402  # isort:skip
+from libreassistant.providers.local import LocalProvider  # noqa: E402  # isort:skip
 
 
 @pytest.fixture
@@ -32,4 +35,7 @@ def reset_kernel() -> Generator[None, None, None]:
     """Reset the microkernel between tests."""
     kernel.reset()
     register_echo()
+    providers.reset()
+    providers.register("cloud", CloudProvider())
+    providers.register("local", LocalProvider())
     yield

--- a/tests/test_echo_plugin.py
+++ b/tests/test_echo_plugin.py
@@ -14,6 +14,9 @@ def test_echo_plugin_integration(client) -> None:
     assert response.status_code == 200
     assert response.json() == {
         "result": {"echo": "hi"},
-        "state": {"last_message": "hi"},
+        "state": {
+            "last_message": "hi",
+            "history": [{"plugin": "echo", "payload": {"message": "hi"}}],
+        },
     }
 

--- a/tests/test_history.py
+++ b/tests/test_history.py
@@ -1,0 +1,19 @@
+# Copyright (c) 2024 LibreAssistant contributors.
+# Licensed under the MIT License.
+
+"""Tests for recording and retrieving past requests."""
+
+from __future__ import annotations
+
+
+def test_history_tracks_invocations(client) -> None:
+    payload1 = {"message": "hi"}
+    payload2 = {"message": "bye"}
+    client.post("/api/v1/invoke", json={"plugin": "echo", "payload": payload1, "user_id": "alice"})
+    client.post("/api/v1/invoke", json={"plugin": "echo", "payload": payload2, "user_id": "alice"})
+    response = client.get("/api/v1/history/alice")
+    assert response.status_code == 200
+    assert response.json()["history"] == [
+        {"plugin": "echo", "payload": payload1},
+        {"plugin": "echo", "payload": payload2},
+    ]

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -29,5 +29,5 @@ def test_user_state_persists(client) -> None:
     )
     assert first.json()["result"] == {"count": 1}
     assert second.json()["result"] == {"count": 2}
-    assert second.json()["state"] == {"count": 2}
+    assert second.json()["state"]["count"] == 2
 

--- a/tests/test_prompt.py
+++ b/tests/test_prompt.py
@@ -1,0 +1,12 @@
+# Copyright (c) 2024 LibreAssistant contributors.
+# Licensed under the MIT License.
+
+"""Tests for the initial system prompt."""
+
+from __future__ import annotations
+
+from libreassistant.prompt import SYSTEM_PROMPT
+
+
+def test_system_prompt_mentions_privacy() -> None:
+    assert "privacy" in SYSTEM_PROMPT.lower()

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -1,0 +1,21 @@
+# Copyright (c) 2024 LibreAssistant contributors.
+# Licensed under the MIT License.
+
+"""Tests for provider registry and API endpoints."""
+
+from __future__ import annotations
+
+
+def test_local_provider(client) -> None:
+    response = client.post("/api/v1/generate", json={"provider": "local", "prompt": "hi"})
+    assert response.status_code == 200
+    assert response.json() == {"result": "local:hi"}
+
+
+def test_cloud_provider_requires_key(client) -> None:
+    bad = client.post("/api/v1/generate", json={"provider": "cloud", "prompt": "hi"})
+    assert bad.status_code == 400
+    set_key = client.post("/api/v1/providers/cloud/key", json={"key": "abc"})
+    assert set_key.status_code == 200
+    good = client.post("/api/v1/generate", json={"provider": "cloud", "prompt": "hi"})
+    assert good.json() == {"result": "cloud:hi"}

--- a/tests/test_transparency.py
+++ b/tests/test_transparency.py
@@ -1,0 +1,21 @@
+# Copyright (c) 2024 LibreAssistant contributors.
+# Licensed under the MIT License.
+
+"""Tests for transparency dashboards."""
+
+from __future__ import annotations
+
+
+def test_bom_lists_dependencies(client):
+    resp = client.get("/api/v1/bom")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert "dependencies" in data
+    assert any(dep.startswith("fastapi") for dep in data["dependencies"])
+
+
+def test_health_reports_metrics(client):
+    first = client.get("/api/v1/health").json()["requests"]
+    client.get("/")
+    second = client.get("/api/v1/health").json()["requests"]
+    assert second >= first + 2

--- a/tests/test_vault.py
+++ b/tests/test_vault.py
@@ -1,0 +1,42 @@
+"""Tests for the personal data vault and consent endpoints."""
+from __future__ import annotations
+
+
+def test_vault_crud_and_export(client):
+    user_id = "alice"
+    payload = {"favorite": "cats"}
+
+    resp = client.post(f"/api/v1/vault/{user_id}", json={"data": payload})
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "ok"
+
+    resp = client.get(f"/api/v1/vault/{user_id}")
+    assert resp.status_code == 200
+    assert resp.json()["data"] == payload
+
+    resp = client.get(f"/api/v1/vault/{user_id}/export")
+    assert resp.status_code == 200
+    assert resp.json()["data"] == payload
+
+    resp = client.delete(f"/api/v1/vault/{user_id}")
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "deleted"
+
+    resp = client.get(f"/api/v1/vault/{user_id}")
+    assert resp.status_code == 200
+    assert resp.json()["data"] == {}
+
+
+def test_consent_toggle(client):
+    user_id = "bob"
+    resp = client.get(f"/api/v1/consent/{user_id}")
+    assert resp.status_code == 200
+    assert resp.json()["consent"] is False
+
+    resp = client.post(f"/api/v1/consent/{user_id}", json={"consent": True})
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "ok"
+
+    resp = client.get(f"/api/v1/consent/{user_id}")
+    assert resp.status_code == 200
+    assert resp.json()["consent"] is True

--- a/ui/components/bill-of-materials.js
+++ b/ui/components/bill-of-materials.js
@@ -1,0 +1,57 @@
+// Copyright (c) 2024 LibreAssistant contributors.
+// Licensed under the MIT License.
+
+class LABillOfMaterials extends HTMLElement {
+  constructor() {
+    super();
+    const shadow = this.attachShadow({ mode: 'open' });
+    shadow.innerHTML = `
+      <style>
+        ul { list-style: disc; padding-left: var(--spacing-md); }
+      </style>
+      <h2>Bill of Materials</h2>
+      <section>
+        <h3>Dependencies</h3>
+        <ul id="deps"></ul>
+      </section>
+      <section>
+        <h3>Models</h3>
+        <ul id="models"></ul>
+      </section>
+      <section>
+        <h3>Datasets</h3>
+        <ul id="datasets"></ul>
+      </section>
+    `;
+  }
+
+  async connectedCallback() {
+    try {
+      const resp = await fetch('/api/v1/bom');
+      if (!resp.ok) return;
+      const data = await resp.json();
+      const deps = this.shadowRoot.getElementById('deps');
+      data.dependencies.forEach(d => {
+        const li = document.createElement('li');
+        li.textContent = d;
+        deps.appendChild(li);
+      });
+      const models = this.shadowRoot.getElementById('models');
+      data.models.forEach(m => {
+        const li = document.createElement('li');
+        li.textContent = m;
+        models.appendChild(li);
+      });
+      const datasets = this.shadowRoot.getElementById('datasets');
+      data.datasets.forEach(ds => {
+        const li = document.createElement('li');
+        li.textContent = ds;
+        datasets.appendChild(li);
+      });
+    } catch (err) {
+      // ignore errors for now
+    }
+  }
+}
+
+customElements.define('la-bill-of-materials', LABillOfMaterials);

--- a/ui/components/data-vault.js
+++ b/ui/components/data-vault.js
@@ -1,0 +1,67 @@
+// Copyright (c) 2024 LibreAssistant contributors.
+// Licensed under the MIT License.
+
+class LADataVault extends HTMLElement {
+  constructor() {
+    super();
+    const shadow = this.attachShadow({ mode: 'open' });
+    shadow.innerHTML = `
+      <style>
+        textarea {
+          width: 100%;
+          min-height: 6rem;
+          font-family: var(--font-family-mono);
+          margin-bottom: var(--spacing-sm);
+        }
+        button {
+          margin-right: var(--spacing-sm);
+        }
+        pre {
+          background: var(--color-surface);
+          padding: var(--spacing-sm);
+        }
+      </style>
+      <textarea id="data" placeholder="{}"></textarea>
+      <div>
+        <button id="save">Save</button>
+        <button id="export">Export</button>
+        <button id="delete">Delete</button>
+      </div>
+      <pre id="output"></pre>
+    `;
+  }
+
+  connectedCallback() {
+    const user = this.getAttribute('user') || 'default';
+    const textarea = this.shadowRoot.getElementById('data');
+    const output = this.shadowRoot.getElementById('output');
+
+    this.shadowRoot.getElementById('save').addEventListener('click', async () => {
+      let data = {};
+      try {
+        data = JSON.parse(textarea.value || '{}');
+      } catch (e) {
+        return;
+      }
+      await fetch(`/api/v1/vault/${user}`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ data })
+      });
+    });
+
+    this.shadowRoot.getElementById('export').addEventListener('click', async () => {
+      const resp = await fetch(`/api/v1/vault/${user}/export`);
+      const json = await resp.json();
+      output.textContent = JSON.stringify(json.data, null, 2);
+    });
+
+    this.shadowRoot.getElementById('delete').addEventListener('click', async () => {
+      await fetch(`/api/v1/vault/${user}`, { method: 'DELETE' });
+      output.textContent = '';
+      textarea.value = '';
+    });
+  }
+}
+
+customElements.define('la-data-vault', LADataVault);

--- a/ui/components/index.js
+++ b/ui/components/index.js
@@ -1,0 +1,16 @@
+// Copyright (c) 2024 LibreAssistant contributors.
+// Licensed under the MIT License.
+
+import './primary-button.js';
+import './input-field.js';
+import './information-card.js';
+import './modal-dialog.js';
+import './main-tabs.js';
+import './onboarding-flow.js';
+import './switchboard.js';
+import './plugin-catalogue.js';
+import './past-requests.js';
+import './data-vault.js';
+import './user-profile.js';
+import './bill-of-materials.js';
+import './system-health.js';

--- a/ui/components/information-card.js
+++ b/ui/components/information-card.js
@@ -1,0 +1,35 @@
+// Copyright (c) 2024 LibreAssistant contributors.
+// Licensed under the MIT License.
+
+class LAInformationCard extends HTMLElement {
+  constructor() {
+    super();
+    const shadow = this.attachShadow({ mode: 'open' });
+    shadow.innerHTML = `
+      <style>
+        .card {
+          background-color: var(--color-surface);
+          color: var(--color-text);
+          font-family: var(--font-family-sans);
+          padding: var(--spacing-md);
+          border-radius: var(--radius-md);
+          box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+        }
+        .title {
+          font-size: var(--font-size-lg);
+          font-weight: var(--font-weight-bold);
+          margin-bottom: var(--spacing-sm);
+        }
+        .content {
+          font-size: var(--font-size-base);
+        }
+      </style>
+      <div class="card" role="group" aria-labelledby="title">
+        <div id="title" class="title"><slot name="title"></slot></div>
+        <div class="content"><slot></slot></div>
+      </div>
+    `;
+  }
+}
+
+customElements.define('la-information-card', LAInformationCard);

--- a/ui/components/input-field.js
+++ b/ui/components/input-field.js
@@ -1,0 +1,45 @@
+// Copyright (c) 2024 LibreAssistant contributors.
+// Licensed under the MIT License.
+
+class LAInputField extends HTMLElement {
+  constructor() {
+    super();
+    const shadow = this.attachShadow({ mode: 'open' });
+    shadow.innerHTML = `
+      <style>
+        label {
+          display: flex;
+          flex-direction: column;
+          font-family: var(--font-family-sans);
+          font-size: var(--font-size-sm);
+          color: var(--color-text);
+        }
+        input {
+          padding: var(--spacing-sm);
+          font-family: var(--font-family-sans);
+          font-size: var(--font-size-base);
+          border: 1px solid var(--color-secondary);
+          border-radius: var(--radius-sm);
+        }
+        input:focus {
+          outline: 2px solid var(--color-primary);
+          border-color: var(--color-primary);
+        }
+      </style>
+      <label>
+        <span><slot name="label"></slot></span>
+        <input type="text" />
+      </label>
+    `;
+  }
+
+  get value() {
+    return this.shadowRoot.querySelector('input').value;
+  }
+
+  set value(val) {
+    this.shadowRoot.querySelector('input').value = val;
+  }
+}
+
+customElements.define('la-input-field', LAInputField);

--- a/ui/components/main-tabs.js
+++ b/ui/components/main-tabs.js
@@ -1,0 +1,62 @@
+// Copyright (c) 2024 LibreAssistant contributors.
+// Licensed under the MIT License.
+
+class LAMainTabs extends HTMLElement {
+  constructor() {
+    super();
+    const shadow = this.attachShadow({ mode: 'open' });
+    shadow.innerHTML = `
+      <style>
+        nav {
+          display: flex;
+          gap: var(--spacing-md);
+          border-bottom: 1px solid var(--color-border);
+        }
+        button[role="tab"] {
+          background: none;
+          border: none;
+          padding: var(--spacing-sm) var(--spacing-md);
+          cursor: pointer;
+          font-family: var(--font-family-sans);
+          font-size: var(--font-size-base);
+        }
+        button[aria-selected="true"] {
+          border-bottom: 2px solid var(--color-primary);
+          font-weight: var(--font-weight-bold);
+        }
+        section[role="tabpanel"] {
+          display: none;
+          padding: var(--spacing-md);
+        }
+        section[role="tabpanel"][data-active="true"] {
+          display: block;
+        }
+      </style>
+      <nav role="tablist">
+        <button role="tab" aria-selected="true" id="tab-switchboard">Switchboard</button>
+        <button role="tab" aria-selected="false" id="tab-catalogue">Catalogue</button>
+        <button role="tab" aria-selected="false" id="tab-past">Past Requests</button>
+        <button role="tab" aria-selected="false" id="tab-profile">User Profile</button>
+      </nav>
+      <section id="panel-switchboard" role="tabpanel" data-active="true"><slot name="switchboard"></slot></section>
+      <section id="panel-catalogue" role="tabpanel"><slot name="catalogue"></slot></section>
+      <section id="panel-past" role="tabpanel"><slot name="past"></slot></section>
+      <section id="panel-profile" role="tabpanel"><slot name="profile"></slot></section>
+    `;
+  }
+
+  connectedCallback() {
+    const tabs = this.shadowRoot.querySelectorAll('[role="tab"]');
+    const panels = this.shadowRoot.querySelectorAll('[role="tabpanel"]');
+    tabs.forEach((tab, index) => {
+      tab.addEventListener('click', () => {
+        tabs.forEach(t => t.setAttribute('aria-selected', 'false'));
+        tab.setAttribute('aria-selected', 'true');
+        panels.forEach(p => p.removeAttribute('data-active'));
+        panels[index].setAttribute('data-active', 'true');
+      });
+    });
+  }
+}
+
+customElements.define('la-main-tabs', LAMainTabs);

--- a/ui/components/modal-dialog.js
+++ b/ui/components/modal-dialog.js
@@ -1,0 +1,67 @@
+// Copyright (c) 2024 LibreAssistant contributors.
+// Licensed under the MIT License.
+
+class LAModalDialog extends HTMLElement {
+  constructor() {
+    super();
+    const shadow = this.attachShadow({ mode: 'open' });
+    shadow.innerHTML = `
+      <style>
+        :host {
+          display: none;
+          position: fixed;
+          top: 0;
+          left: 0;
+          width: 100%;
+          height: 100%;
+          align-items: center;
+          justify-content: center;
+        }
+        :host([open]) {
+          display: flex;
+        }
+        .backdrop {
+          position: absolute;
+          top: 0;
+          left: 0;
+          width: 100%;
+          height: 100%;
+          background-color: rgba(0, 0, 0, 0.5);
+        }
+        .dialog {
+          position: relative;
+          background-color: var(--color-background);
+          color: var(--color-text);
+          padding: var(--spacing-lg);
+          border-radius: var(--radius-md);
+          min-width: 300px;
+          max-width: 90%;
+          font-family: var(--font-family-sans);
+        }
+        .close {
+          position: absolute;
+          top: var(--spacing-sm);
+          right: var(--spacing-sm);
+          background: none;
+          border: none;
+          font-size: var(--font-size-lg);
+          cursor: pointer;
+        }
+      </style>
+      <div class="backdrop" part="backdrop"></div>
+      <div class="dialog" role="dialog" aria-modal="true" aria-labelledby="title">
+        <button class="close" aria-label="Close">&times;</button>
+        <div id="title"><slot name="title"></slot></div>
+        <div><slot></slot></div>
+      </div>
+    `;
+
+    const backdrop = shadow.querySelector('.backdrop');
+    const close = shadow.querySelector('.close');
+    const hide = () => this.removeAttribute('open');
+    backdrop.addEventListener('click', hide);
+    close.addEventListener('click', hide);
+  }
+}
+
+customElements.define('la-modal-dialog', LAModalDialog);

--- a/ui/components/onboarding-flow.js
+++ b/ui/components/onboarding-flow.js
@@ -1,0 +1,74 @@
+// Copyright (c) 2024 LibreAssistant contributors.
+// Licensed under the MIT License.
+
+class LAOnboardingFlow extends HTMLElement {
+  constructor() {
+    super();
+    this.step = 0;
+    const shadow = this.attachShadow({ mode: 'open' });
+    shadow.innerHTML = `
+      <style>
+        [hidden] { display: none; }
+        .step { padding: var(--spacing-md); }
+        .controls {
+          display: flex;
+          justify-content: space-between;
+          margin-top: var(--spacing-md);
+        }
+        button {
+          background-color: var(--color-primary);
+          color: var(--color-background);
+          font-family: var(--font-family-sans);
+          font-size: var(--font-size-base);
+          padding: var(--spacing-sm) var(--spacing-md);
+          border: none;
+          border-radius: var(--radius-md);
+          cursor: pointer;
+        }
+        button[disabled] {
+          opacity: 0.5;
+          cursor: default;
+        }
+      </style>
+      <div class="step" data-step="0">Step 1: Choose AI engine</div>
+      <div class="step" data-step="1" hidden>Step 2: Select provider</div>
+      <div class="step" data-step="2" hidden>Step 3: Configure plugins</div>
+      <div class="step" data-step="3" hidden>Step 4: Review permissions</div>
+      <div class="step" data-step="4" hidden>Step 5: Privacy briefing</div>
+      <div class="step" data-step="5" hidden>Step 6: Completion</div>
+      <div class="controls">
+        <button id="back">Back</button>
+        <button id="next">Next</button>
+      </div>
+    `;
+  }
+
+  connectedCallback() {
+    this.backBtn = this.shadowRoot.getElementById('back');
+    this.nextBtn = this.shadowRoot.getElementById('next');
+    this.steps = this.shadowRoot.querySelectorAll('.step');
+    this.update();
+    this.backBtn.addEventListener('click', () => {
+      if (this.step > 0) {
+        this.step -= 1;
+        this.update();
+      }
+    });
+    this.nextBtn.addEventListener('click', () => {
+      if (this.step < this.steps.length - 1) {
+        this.step += 1;
+        this.update();
+      }
+    });
+  }
+
+  update() {
+    this.steps.forEach((el, idx) => {
+      el.hidden = idx !== this.step;
+    });
+    this.backBtn.disabled = this.step === 0;
+    this.nextBtn.disabled = this.step === this.steps.length - 1;
+  }
+}
+
+customElements.define('la-onboarding-flow', LAOnboardingFlow);

--- a/ui/components/past-requests.js
+++ b/ui/components/past-requests.js
@@ -1,0 +1,38 @@
+// Copyright (c) 2024 LibreAssistant contributors.
+// Licensed under the MIT License.
+
+class LAPastRequests extends HTMLElement {
+  constructor() {
+    super();
+    const shadow = this.attachShadow({ mode: 'open' });
+    shadow.innerHTML = `
+      <style>
+        ul {
+          list-style: disc;
+          padding-left: var(--spacing-md);
+          font-family: var(--font-family-sans);
+        }
+      </style>
+      <ul id="list"></ul>
+    `;
+  }
+
+  async connectedCallback() {
+    const user = this.getAttribute('user-id') || 'anonymous';
+    try {
+      const res = await fetch(`/api/v1/history/${user}`);
+      if (!res.ok) return;
+      const data = await res.json();
+      const list = this.shadowRoot.getElementById('list');
+      data.history.forEach(entry => {
+        const li = document.createElement('li');
+        li.textContent = `${entry.plugin}: ${JSON.stringify(entry.payload)}`;
+        list.appendChild(li);
+      });
+    } catch (err) {
+      // ignore errors for now
+    }
+  }
+}
+
+customElements.define('la-past-requests', LAPastRequests);

--- a/ui/components/plugin-catalogue.js
+++ b/ui/components/plugin-catalogue.js
@@ -1,0 +1,97 @@
+// Copyright (c) 2024 LibreAssistant contributors.
+// Licensed under the MIT License.
+
+class LAPluginCatalogue extends HTMLElement {
+  constructor() {
+    super();
+    const shadow = this.attachShadow({ mode: 'open' });
+    shadow.innerHTML = `
+      <style>
+        :host {
+          display: block;
+          font-family: var(--font-family-sans);
+        }
+        header {
+          margin-bottom: var(--spacing-md);
+        }
+        ul {
+          list-style: none;
+          padding: 0;
+          margin: 0;
+          display: flex;
+          flex-direction: column;
+          gap: var(--spacing-sm);
+        }
+        li {
+          display: flex;
+          justify-content: space-between;
+          align-items: center;
+          padding: var(--spacing-sm);
+          border: 1px solid var(--color-border);
+          border-radius: var(--radius-sm);
+        }
+        label {
+          display: flex;
+          align-items: center;
+          gap: var(--spacing-sm);
+          font-size: var(--font-size-base);
+          color: var(--color-text);
+        }
+      </style>
+      <header>
+        <la-input-field id="search">
+          <span slot="label">Search plugins</span>
+        </la-input-field>
+      </header>
+      <ul id="list"></ul>
+    `;
+    this.plugins = [
+      { name: 'Weather', enabled: false },
+      { name: 'Calculator', enabled: false },
+      { name: 'Notes', enabled: false },
+      { name: 'Calendar', enabled: false },
+    ];
+  }
+
+  connectedCallback() {
+    this.render();
+    const search = this.shadowRoot.getElementById('search');
+    search.shadowRoot.querySelector('input').addEventListener('input', e => {
+      this.filter(e.target.value);
+    });
+  }
+
+  filter(query) {
+    const lower = query.toLowerCase();
+    this.shadowRoot.getElementById('list').innerHTML = '';
+    this.plugins
+      .filter(p => p.name.toLowerCase().includes(lower))
+      .forEach(p => this.addItem(p));
+  }
+
+  render() {
+    const list = this.shadowRoot.getElementById('list');
+    list.innerHTML = '';
+    this.plugins.forEach(p => this.addItem(p));
+  }
+
+  addItem(plugin) {
+    const li = document.createElement('li');
+    const label = document.createElement('label');
+    label.textContent = plugin.name;
+    const toggle = document.createElement('input');
+    toggle.type = 'checkbox';
+    toggle.checked = plugin.enabled;
+    toggle.addEventListener('change', () => {
+      plugin.enabled = toggle.checked;
+      this.dispatchEvent(new CustomEvent('plugin-toggle', {
+        detail: { name: plugin.name, enabled: plugin.enabled }
+      }));
+    });
+    label.prepend(toggle);
+    li.appendChild(label);
+    this.shadowRoot.getElementById('list').appendChild(li);
+  }
+}
+
+customElements.define('la-plugin-catalogue', LAPluginCatalogue);

--- a/ui/components/primary-button.js
+++ b/ui/components/primary-button.js
@@ -1,0 +1,32 @@
+// Copyright (c) 2024 LibreAssistant contributors.
+// Licensed under the MIT License.
+
+class LAPrimaryButton extends HTMLElement {
+  constructor() {
+    super();
+    const shadow = this.attachShadow({ mode: 'open' });
+    shadow.innerHTML = `
+      <style>
+        button {
+          background-color: var(--color-primary);
+          color: var(--color-background);
+          font-family: var(--font-family-sans);
+          font-size: var(--font-size-base);
+          font-weight: var(--font-weight-bold);
+          padding: var(--spacing-sm) var(--spacing-md);
+          border: none;
+          border-radius: var(--radius-md);
+          cursor: pointer;
+        }
+        button:hover,
+        button:focus {
+          background-color: var(--color-primary-hover);
+          outline: none;
+        }
+      </style>
+      <button type="button"><slot></slot></button>
+    `;
+  }
+}
+
+customElements.define('la-primary-button', LAPrimaryButton);

--- a/ui/components/switchboard.js
+++ b/ui/components/switchboard.js
@@ -1,0 +1,83 @@
+// Copyright (c) 2024 LibreAssistant contributors.
+// Licensed under the MIT License.
+
+class LASwitchboard extends HTMLElement {
+  constructor() {
+    super();
+    const shadow = this.attachShadow({ mode: 'open' });
+    shadow.innerHTML = `
+      <style>
+        .request { display: flex; gap: var(--spacing-sm); }
+        textarea {
+          flex: 1;
+          font-family: var(--font-family-sans);
+          font-size: var(--font-size-base);
+          padding: var(--spacing-sm);
+          border: 1px solid var(--color-border);
+          border-radius: var(--radius-sm);
+        }
+        button {
+          background-color: var(--color-primary);
+          color: var(--color-background);
+          border: none;
+          border-radius: var(--radius-sm);
+          padding: var(--spacing-sm) var(--spacing-md);
+          cursor: pointer;
+        }
+        .plugins {
+          display: grid;
+          grid-template-columns: repeat(4, 1fr);
+          gap: var(--spacing-sm);
+          margin-top: var(--spacing-md);
+        }
+        .plugins slot {
+          border: 1px dashed var(--color-border);
+          border-radius: var(--radius-sm);
+          min-height: 40px;
+        }
+        .activity {
+          margin-top: var(--spacing-md);
+          font-family: var(--font-family-sans);
+        }
+      </style>
+      <div class="request">
+        <textarea id="input" aria-label="Request"></textarea>
+        <button id="send">Send</button>
+      </div>
+      <div class="plugins">
+        <slot name="plugin-1"></slot>
+        <slot name="plugin-2"></slot>
+        <slot name="plugin-3"></slot>
+        <slot name="plugin-4"></slot>
+        <slot name="plugin-5"></slot>
+        <slot name="plugin-6"></slot>
+        <slot name="plugin-7"></slot>
+        <slot name="plugin-8"></slot>
+        <slot name="plugin-9"></slot>
+        <slot name="plugin-10"></slot>
+        <slot name="plugin-11"></slot>
+        <slot name="plugin-12"></slot>
+      </div>
+      <div class="activity">
+        <ul id="log"></ul>
+      </div>
+    `;
+  }
+
+  connectedCallback() {
+    const send = this.shadowRoot.getElementById('send');
+    const input = this.shadowRoot.getElementById('input');
+    const log = this.shadowRoot.getElementById('log');
+    send.addEventListener('click', () => {
+      const value = input.value.trim();
+      if (value) {
+        const li = document.createElement('li');
+        li.textContent = value;
+        log.appendChild(li);
+        input.value = '';
+      }
+    });
+  }
+}
+
+customElements.define('la-switchboard', LASwitchboard);

--- a/ui/components/system-health.js
+++ b/ui/components/system-health.js
@@ -1,0 +1,46 @@
+// Copyright (c) 2024 LibreAssistant contributors.
+// Licensed under the MIT License.
+
+class LASystemHealth extends HTMLElement {
+  constructor() {
+    super();
+    const shadow = this.attachShadow({ mode: 'open' });
+    shadow.innerHTML = `
+      <style>
+        ul { list-style: disc; padding-left: var(--spacing-md); }
+      </style>
+      <h2>System Health</h2>
+      <div id="content"></div>
+    `;
+  }
+
+  async connectedCallback() {
+    await this.refresh();
+  }
+
+  async refresh() {
+    try {
+      const resp = await fetch('/api/v1/health');
+      if (!resp.ok) return;
+      const data = await resp.json();
+      const content = this.shadowRoot.getElementById('content');
+      content.innerHTML = `
+        <p>Status: ${data.status}</p>
+        <p>Uptime: ${Math.round(data.uptime)}</p>
+        <p>Requests: ${data.requests}</p>
+        <h3>Errors</h3>
+        <ul id="errors"></ul>
+      `;
+      const list = this.shadowRoot.getElementById('errors');
+      data.errors.forEach(e => {
+        const li = document.createElement('li');
+        li.textContent = e;
+        list.appendChild(li);
+      });
+    } catch (err) {
+      // ignore errors for now
+    }
+  }
+}
+
+customElements.define('la-system-health', LASystemHealth);

--- a/ui/components/user-profile.js
+++ b/ui/components/user-profile.js
@@ -1,0 +1,34 @@
+// Copyright (c) 2024 LibreAssistant contributors.
+// Licensed under the MIT License.
+
+class LAUserProfile extends HTMLElement {
+  constructor() {
+    super();
+    const shadow = this.attachShadow({ mode: 'open' });
+    shadow.innerHTML = `
+      <style>
+        :host { display: block; }
+        label { display: flex; align-items: center; gap: var(--spacing-sm); }
+      </style>
+      <label><input type="checkbox" id="consent"> Allow data storage</label>
+      <la-data-vault></la-data-vault>
+    `;
+  }
+
+  connectedCallback() {
+    const user = this.getAttribute('user') || 'default';
+    const checkbox = this.shadowRoot.getElementById('consent');
+    fetch(`/api/v1/consent/${user}`).then(r => r.json()).then(j => {
+      checkbox.checked = j.consent;
+    });
+    checkbox.addEventListener('change', async () => {
+      await fetch(`/api/v1/consent/${user}`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ consent: checkbox.checked })
+      });
+    });
+  }
+}
+
+customElements.define('la-user-profile', LAUserProfile);

--- a/ui/tokens.css
+++ b/ui/tokens.css
@@ -1,0 +1,32 @@
+/* Copyright (c) 2024 LibreAssistant contributors.
+   Licensed under the MIT License. */
+
+:root {
+  /* Color palette */
+  --color-primary: #0d6efd;
+  --color-primary-hover: #0b5ed7;
+  --color-secondary: #6c757d;
+  --color-background: #ffffff;
+  --color-surface: #f8f9fa;
+  --color-text: #212529;
+
+  /* Typography */
+  --font-family-sans: 'Helvetica Neue', Arial, sans-serif;
+  --font-size-base: 16px;
+  --font-size-lg: 18px;
+  --font-size-sm: 14px;
+  --font-weight-normal: 400;
+  --font-weight-bold: 600;
+
+  /* Spacing scale */
+  --spacing-xs: 4px;
+  --spacing-sm: 8px;
+  --spacing-md: 16px;
+  --spacing-lg: 24px;
+  --spacing-xl: 32px;
+
+  /* Border radii */
+  --radius-sm: 4px;
+  --radius-md: 8px;
+  --radius-lg: 16px;
+}


### PR DESCRIPTION
## Summary
- add Bill of Materials and system health endpoints with middleware tracking
- create Bill of Materials and System Health web components and register them
- add tests covering transparency API behavior
- document phase 3 features and endpoints in README and API guide

## Testing
- `python -m pip install -e .[dev]`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68995eb9b1cc8332a93ddecfeb9d13af