### PR TITLE
Require explicit consent for data vault operations

### DIFF
--- a/src/libreassistant/main.py
+++ b/src/libreassistant/main.py
@@ -81,20 +81,34 @@ def create_app() -> FastAPI:
 
     @app.post("/api/v1/vault/{user_id}")
     def store_data(user_id: str, request: VaultData) -> Dict[str, str]:
-        vault.store(user_id, request.data)
+        try:
+            vault.store(user_id, request.data)
+        except PermissionError:
+            raise HTTPException(status_code=403, detail="Consent required")
         return {"status": "ok"}
 
     @app.get("/api/v1/vault/{user_id}")
     def get_data(user_id: str) -> Dict[str, Any]:
-        return {"data": vault.retrieve(user_id)}
+        try:
+            data = vault.retrieve(user_id)
+        except PermissionError:
+            raise HTTPException(status_code=403, detail="Consent required")
+        return {"data": data}
 
     @app.get("/api/v1/vault/{user_id}/export")
     def export_data(user_id: str) -> Dict[str, Any]:
-        return {"data": vault.export(user_id)}
+        try:
+            data = vault.export(user_id)
+        except PermissionError:
+            raise HTTPException(status_code=403, detail="Consent required")
+        return {"data": data}
 
     @app.delete("/api/v1/vault/{user_id}")
     def delete_data(user_id: str) -> Dict[str, str]:
-        vault.delete(user_id)
+        try:
+            vault.delete(user_id)
+        except PermissionError:
+            raise HTTPException(status_code=403, detail="Consent required")
         return {"status": "deleted"}
 
     class Consent(BaseModel):

--- a/src/libreassistant/vault.py
+++ b/src/libreassistant/vault.py
@@ -18,12 +18,19 @@ class DataVault:
         self._data: Dict[str, bytes] = {}
         self._consent: Dict[str, bool] = {}
 
+    def _require_consent(self, user_id: str) -> None:
+        """Raise ``PermissionError`` if the user has not granted consent."""
+        if not self._consent.get(user_id, False):
+            raise PermissionError("Consent required")
+
     def store(self, user_id: str, data: Dict[str, Any]) -> None:
+        self._require_consent(user_id)
         payload = json.dumps(data).encode()
         token = self._fernet.encrypt(payload)
         self._data[user_id] = token
 
     def retrieve(self, user_id: str) -> Dict[str, Any]:
+        self._require_consent(user_id)
         token = self._data.get(user_id)
         if not token:
             return {}
@@ -31,10 +38,12 @@ class DataVault:
         return json.loads(payload.decode())
 
     def delete(self, user_id: str) -> None:
+        self._require_consent(user_id)
         self._data.pop(user_id, None)
         self._consent.pop(user_id, None)
 
     def export(self, user_id: str) -> Dict[str, Any]:
+        self._require_consent(user_id)
         return self.retrieve(user_id)
 
     def set_consent(self, user_id: str, consent: bool) -> None:

--- a/tests/test_vault.py
+++ b/tests/test_vault.py
@@ -9,6 +9,9 @@ def test_vault_crud_and_export(client):
     user_id = "alice"
     payload = {"favorite": "cats"}
 
+    resp = client.post(f"/api/v1/consent/{user_id}", json={"consent": True})
+    assert resp.status_code == 200
+
     resp = client.post(f"/api/v1/vault/{user_id}", json={"data": payload})
     assert resp.status_code == 200
     assert resp.json()["status"] == "ok"
@@ -24,6 +27,9 @@ def test_vault_crud_and_export(client):
     resp = client.delete(f"/api/v1/vault/{user_id}")
     assert resp.status_code == 200
     assert resp.json()["status"] == "deleted"
+
+    resp = client.post(f"/api/v1/consent/{user_id}", json={"consent": True})
+    assert resp.status_code == 200
 
     resp = client.get(f"/api/v1/vault/{user_id}")
     assert resp.status_code == 200
@@ -43,3 +49,24 @@ def test_consent_toggle(client):
     resp = client.get(f"/api/v1/consent/{user_id}")
     assert resp.status_code == 200
     assert resp.json()["consent"] is True
+
+
+def test_vault_requires_consent(client):
+    user_id = "eve"
+    payload = {"pet": "parrot"}
+
+    resp = client.post(f"/api/v1/vault/{user_id}", json={"data": payload})
+    assert resp.status_code == 403
+
+    resp = client.get(f"/api/v1/vault/{user_id}")
+    assert resp.status_code == 403
+
+    resp = client.post(f"/api/v1/consent/{user_id}", json={"consent": True})
+    assert resp.status_code == 200
+
+    resp = client.post(f"/api/v1/vault/{user_id}", json={"data": payload})
+    assert resp.status_code == 200
+
+    resp = client.get(f"/api/v1/vault/{user_id}")
+    assert resp.status_code == 200
+    assert resp.json()["data"] == payload

--- a/ui/components/data-vault.js
+++ b/ui/components/data-vault.js
@@ -32,35 +32,65 @@ class LADataVault extends HTMLElement {
   }
 
   connectedCallback() {
-    const user = this.getAttribute('user') || 'default';
-    const textarea = this.shadowRoot.getElementById('data');
-    const output = this.shadowRoot.getElementById('output');
+    this.user = this.getAttribute('user') || 'default';
+    this.textarea = this.shadowRoot.getElementById('data');
+    this.output = this.shadowRoot.getElementById('output');
+    this.saveBtn = this.shadowRoot.getElementById('save');
+    this.exportBtn = this.shadowRoot.getElementById('export');
+    this.deleteBtn = this.shadowRoot.getElementById('delete');
 
-    this.shadowRoot.getElementById('save').addEventListener('click', async () => {
+    fetch(`/api/v1/consent/${this.user}`)
+      .then(r => r.json())
+      .then(j => this.updateConsent(j.consent));
+
+    this.saveBtn.addEventListener('click', async () => {
       let data = {};
       try {
-        data = JSON.parse(textarea.value || '{}');
+        data = JSON.parse(this.textarea.value || '{}');
       } catch (e) {
         return;
       }
-      await fetch(`/api/v1/vault/${user}`, {
+      const resp = await fetch(`/api/v1/vault/${this.user}`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ data })
       });
+      if (resp.status === 403) {
+        this.output.textContent = 'Consent required';
+      }
     });
 
-    this.shadowRoot.getElementById('export').addEventListener('click', async () => {
-      const resp = await fetch(`/api/v1/vault/${user}/export`);
+    this.exportBtn.addEventListener('click', async () => {
+      const resp = await fetch(`/api/v1/vault/${this.user}/export`);
+      if (resp.status === 403) {
+        this.output.textContent = 'Consent required';
+        return;
+      }
       const json = await resp.json();
-      output.textContent = JSON.stringify(json.data, null, 2);
+      this.output.textContent = JSON.stringify(json.data, null, 2);
     });
 
-    this.shadowRoot.getElementById('delete').addEventListener('click', async () => {
-      await fetch(`/api/v1/vault/${user}`, { method: 'DELETE' });
-      output.textContent = '';
-      textarea.value = '';
+    this.deleteBtn.addEventListener('click', async () => {
+      const resp = await fetch(`/api/v1/vault/${this.user}`, { method: 'DELETE' });
+      if (resp.status === 403) {
+        this.output.textContent = 'Consent required';
+        return;
+      }
+      this.output.textContent = '';
+      this.textarea.value = '';
     });
+  }
+
+  updateConsent(consent) {
+    const disabled = !consent;
+    this.saveBtn.disabled = disabled;
+    this.exportBtn.disabled = disabled;
+    this.deleteBtn.disabled = disabled;
+    if (disabled) {
+      this.output.textContent = 'Consent required';
+    } else {
+      this.output.textContent = '';
+    }
   }
 }
 

--- a/ui/components/user-profile.js
+++ b/ui/components/user-profile.js
@@ -18,8 +18,12 @@ class LAUserProfile extends HTMLElement {
   connectedCallback() {
     const user = this.getAttribute('user') || 'default';
     const checkbox = this.shadowRoot.getElementById('consent');
+    const vault = this.shadowRoot.querySelector('la-data-vault');
     fetch(`/api/v1/consent/${user}`).then(r => r.json()).then(j => {
       checkbox.checked = j.consent;
+      if (vault && typeof vault.updateConsent === 'function') {
+        vault.updateConsent(j.consent);
+      }
     });
     checkbox.addEventListener('change', async () => {
       await fetch(`/api/v1/consent/${user}`, {
@@ -27,6 +31,9 @@ class LAUserProfile extends HTMLElement {
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ consent: checkbox.checked })
       });
+      if (vault && typeof vault.updateConsent === 'function') {
+        vault.updateConsent(checkbox.checked);
+      }
     });
   }
 }


### PR DESCRIPTION
## Summary
- Enforce consent checks in `DataVault` before storing, retrieving, exporting or deleting data
- Return HTTP 403 from `/api/v1/vault/` endpoints when consent is missing
- Add unit tests confirming vault access fails without consent and succeeds once granted
- Update UI components to disable vault actions and show errors when consent is absent

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689a889035048332aaa8648ecf163d9e