### PR TITLE
Harden theme CSS loading against imports and path traversal

### DIFF
--- a/src/libreassistant/themes.py
+++ b/src/libreassistant/themes.py
@@ -29,18 +29,21 @@ def sanitize_css(css_text: str) -> str:
     parser = cssutils.CSSParser()
     sheet = parser.parseString(css_text)
     for rule in list(sheet.cssRules):
-        if rule.type == rule.STYLE_RULE:
-            for prop in list(rule.style):
-                if prop.name not in SAFE_PROPERTIES and not prop.name.startswith("--"):
-                    rule.style.removeProperty(prop.name)
+        if rule.type != rule.STYLE_RULE:
+            sheet.deleteRule(rule)
+            continue
+        for prop in list(rule.style):
+            if prop.name not in SAFE_PROPERTIES and not prop.name.startswith("--"):
+                rule.style.removeProperty(prop.name)
     cssutils.ser.prefs.useMinified()
     return sheet.cssText.decode("utf-8")
 
 
 def get_theme_css(theme_id: str) -> str:
     """Load and sanitize CSS for the given theme id."""
-    path = THEME_DIR / f"{theme_id}.css"
-    if not path.exists():
+    allowed = {p.stem for p in THEME_DIR.glob("*.css")}
+    if theme_id not in allowed:
         raise FileNotFoundError(f"Theme '{theme_id}' not found")
+    path = THEME_DIR / f"{theme_id}.css"
     css = path.read_text()
     return sanitize_css(css)

--- a/tests/test_theme_security.py
+++ b/tests/test_theme_security.py
@@ -5,6 +5,7 @@
 
 from __future__ import annotations
 
+import pytest
 import libreassistant.themes as themes
 
 
@@ -12,6 +13,13 @@ def test_sanitize_css_removes_disallowed_properties():
     css = ".a{color:red;position:absolute;}"
     cleaned = themes.sanitize_css(css)
     assert "position" not in cleaned
+    assert "color:red" in cleaned
+
+
+def test_sanitize_css_removes_imports():
+    css = '@import "evil.css"; .a{color:red;}'
+    cleaned = themes.sanitize_css(css)
+    assert "@import" not in cleaned
     assert "color:red" in cleaned
 
 
@@ -30,3 +38,11 @@ def test_csp_header_present(client):
     csp = res.headers.get("content-security-policy")
     assert csp is not None
     assert "default-src 'self'" in csp
+
+
+def test_get_theme_css_rejects_path_traversal(tmp_path, monkeypatch):
+    good = tmp_path / "good.css"
+    good.write_text(".a{color:blue;}")
+    monkeypatch.setattr(themes, "THEME_DIR", tmp_path)
+    with pytest.raises(FileNotFoundError):
+        themes.get_theme_css("../good")


### PR DESCRIPTION
## Summary
- sanitize CSS by removing non-style rules like `@import`
- validate theme IDs against available themes to prevent path traversal
- add regression tests for CSS import stripping and path traversal handling

## Testing
- `pytest tests/test_theme_security.py -q`

------
https://chatgpt.com/codex/tasks/task_e_689a8f0fa0a08332b1aed564c3ba0de5