### PR TITLE
Flag health monitor errors in status

### DIFF
--- a/src/libreassistant/transparency.py
+++ b/src/libreassistant/transparency.py
@@ -31,8 +31,9 @@ class HealthMonitor:
 
     def get_status(self) -> Dict[str, Any]:
         """Return a snapshot of current system health metrics."""
+        status = "error" if self.error_count > 0 else "ok"
         return {
-            "status": "ok",
+            "status": status,
             "uptime": time.time() - self.start_time,
             "requests": self.requests,
             "error_count": self.error_count,

--- a/tests/test_transparency.py
+++ b/tests/test_transparency.py
@@ -30,8 +30,10 @@ def test_error_tracking(client):
 
         return Response(status_code=500)
 
-    before = client.get("/api/v1/health").json()["error_count"]
+    before_status = client.get("/api/v1/health").json()
+    assert before_status["status"] == "ok"
     resp = client.get("/fail")
     assert resp.status_code == 500
-    after = client.get("/api/v1/health").json()["error_count"]
-    assert after == before + 1
+    after_status = client.get("/api/v1/health").json()
+    assert after_status["error_count"] == before_status["error_count"] + 1
+    assert after_status["status"] == "error"


### PR DESCRIPTION
## Summary
- mark health monitor status as error whenever errors are recorded
- test failing requests trigger error status

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_689aa6e2b198833291a2c925e76bca92