### PR TITLE
feat(mcp): expose servers to UI and microkernel

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,5 +20,7 @@ jobs:
       - run: python scripts/check_license_headers.py
       - uses: actions/setup-node@v4
         with:
-          node-version: '18'
+          node-version: '20'
+      - run: npm ci
+      - run: npm test
       - run: npx --yes markdownlint-cli '**/*.md'

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,8 @@
 __pycache__/
 *.py[cod]
 *$py.class
+node_modules/
+mcp_fs/
 
 # C extensions
 *.so

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,0 +1,19 @@
+# Architecture Review
+
+## Current Flow
+```
+User → Switchboard → Plugin → User State → History
+```
+Plugins are Python objects registered in a microkernel. Each invocation mutates per‑user state and the API logs history entries.
+
+## Target MCP Flow
+```
+User → Switchboard → MCP Client → MCP Server Tool → Audit Log
+```
+The switchboard embeds an MCP client which discovers servers via registry allow‑list. Tools perform work and return JSON results while the client records audit entries. Legacy plugins remain available during migration.
+
+### Integration Gaps
+- No schema validation for plugin inputs
+- Transport is tightly coupled to in‑process calls
+- No central allow‑list or consent UX
+- Lacks network controls and audit trail for file operations

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,0 +1,18 @@
+# MCP Migration Plan
+
+## Phase 1 – Client & Registry
+* Add TypeScript MCP client and registry loader
+* Ship reference servers and unit tests
+
+## Phase 2 – Plugin Conversion
+* Re‑implement Echo, File I/O, Law by Keystone and ThinkTank as MCP servers
+* Expose tools, resources and prompts per server
+
+## Phase 3 – Switchboard Integration
+* Wrap MCP client with adapter for UI
+* Enable server discovery and tool execution from switchboard
+
+## Phase 4 – Security & CI
+* Prompt for destructive file operations
+* Capture audit logs and enforce network deny‑list
+* Add tests to CI pipeline

--- a/OVERVIEW.md
+++ b/OVERVIEW.md
@@ -1,0 +1,19 @@
+# Model Context Protocol Overview
+
+Model Context Protocol (MCP) defines a neutral interface between AI clients and external capability providers. It addresses the classic N×M integration problem by standardising how models discover and use tools, resources and prompts.
+
+## Architecture
+MCP adopts a client–server model built on JSON‑RPC 2.0 transported over stdio or HTTP/SSE. Clients initiate a capability discovery handshake where each server advertises its tools, resources and prompts. Once registered, the client issues JSON‑RPC calls to invoke tools and receive structured responses.
+
+### Primitives
+* **Tools** – callable functions with JSON‑Schema validated parameters and return values.
+* **Resources** – read‑only URIs exposing data such as files or status objects.
+* **Prompts** – templated text the client may render before tool invocation.
+
+## Threat Model & Mitigations
+Threats include prompt injection, tool poisoning and malicious servers. Without RBAC the system mitigates risk through:
+- explicit server allow‑lists
+- consent prompts for destructive operations
+- a deny‑by‑default network policy
+- filesystem jails for file tools
+- exhaustive audit logging of JSON‑RPC frames

--- a/PLUGIN-CONVERSIONS.md
+++ b/PLUGIN-CONVERSIONS.md
@@ -1,0 +1,28 @@
+# Plugin Conversion Notes
+
+## Echo Plugin → MCP
+- Tool `echo_message`
+- Params: `{ message: string }`
+- Returns: `{ echo: string }`
+- Resource: `echo:last_message`
+- Prompt: `echo_template`
+
+## File I/O Plugin → MCP
+- Tools: `fs_read`, `fs_create`, `fs_update` (confirm required), `fs_delete` (confirm required), `fs_list`
+- Params/Returns follow JSON Schemas in server implementation
+- Resources: `file://` and `dir://` style URIs managed by the server
+- Prompt: `file_edit_template`
+
+## Law by Keystone → MCP
+- Tool `generate_legal_summary`
+- Params: `{ query: string, output_format: md|txt|json, output_path?: string }`
+- Returns: `{ summary: string, export_path?: string }`
+- Resource: `law:last_summary`
+- Prompt: `legal_research_template`
+
+## ThinkTank → MCP
+- Tool `analyze_goal`
+- Params: `{ goal: string }`
+- Returns structured dossier with `summary` and `analysis` fields
+- Resource: `thinktank:last_dossier`
+- Prompt: `thinktank_question_template`

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,14 @@
+# Security Notes
+
+## Consent Model
+Dangerous tools such as `fs_update` and `fs_delete` require an explicit `confirm: true` parameter. The UI should display a modal explaining the risk before submission.
+
+## Audit Schema
+Every invocation records `{server, tool, params, result, timestamp, beforeHash?, afterHash?}`. File operations hash contents before and after mutation.
+
+## Network Rules
+Servers operate under a deny‑by‑default egress policy. Only hosts listed in
+`config/mcp.registry.json` under the `allowedHosts` array may be contacted.
+
+## File Jail
+The file server resolves paths within `mcp_fs/` and rejects attempts to escape the directory, providing a simple sandbox for local CRUD operations.

--- a/UI-SPEC-MCP.md
+++ b/UI-SPEC-MCP.md
@@ -1,0 +1,3 @@
+# MCP Server Manager UI
+
+The switchboard lists discovered servers in a side panel. Each entry expands to show available tools, resources and prompts. Dangerous tools display a confirmation modal before execution. The history view includes JSON‑formatted audit entries for every call.

--- a/config/mcp.registry.json
+++ b/config/mcp.registry.json
@@ -1,0 +1,9 @@
+{
+  "servers": [
+    { "name": "echo", "module": "./servers/echo/index.ts" },
+    { "name": "files", "module": "./servers/files/index.ts" },
+    { "name": "law_by_keystone", "module": "./servers/law_by_keystone/index.ts" },
+    { "name": "think_tank", "module": "./servers/think_tank/index.ts" }
+  ],
+  "allowedHosts": ["localhost"]
+}

--- a/logs/.gitignore
+++ b/logs/.gitignore
@@ -1,0 +1,3 @@
+*
+!.gitignore
+!README.md

--- a/logs/README.md
+++ b/logs/README.md
@@ -1,0 +1,5 @@
+# Audit logs
+
+This directory stores runtime audit logs in newline-delimited JSON (NDJSON) format.
+Each line represents an `AuditEntry` emitted by the MCP client. Logs rotate when
+the file exceeds 5 MB, renaming the current file to `audit.ndjson.1`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,292 @@
+{
+  "name": "libreassistant-mcp",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "libreassistant-mcp",
+      "version": "0.1.0",
+      "dependencies": {
+        "ajv": "^8.12.0"
+      },
+      "devDependencies": {
+        "ts-node": "^10.9.1",
+        "typescript": "^5.3.3"
+      }
+    },
+    "node_modules/@cspotcode/source-map-support": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "0.3.9"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.0.3",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
+    "node_modules/@tsconfig/node10": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.11.tgz",
+      "integrity": "sha512-DcRjDCujK/kCk/cUe8Xz8ZSpm8mS3mNNpta+jGCA6USEDfktlNvm1+IuZ9eTcDbNk41BHwpHHeW+N1lKCz4zOw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node12": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
+      "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node14": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
+      "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node16": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
+      "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "24.3.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.3.0.tgz",
+      "integrity": "sha512-aPTXCrfwnDLj4VvXrm+UUCQjNEvJgNA8s5F1cvwQU+3KNltTOkBm1j30uNLyqqPNe7gE3KFzImYoZEfLhp4Yow==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "undici-types": "~7.10.0"
+      }
+    },
+    "node_modules/acorn": {
+      "version": "8.15.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
+      "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-walk": {
+      "version": "8.3.4",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.4.tgz",
+      "integrity": "sha512-ueEepnujpqee2o5aIYnvHU6C0A42MNdsIDeqy5BydrkuC5R1ZuUFnm27EeFJGoEHJQgn3uleRvmTXaJgfXbt4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.11.0"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "8.17.1",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
+      "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/arg": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/create-require": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
+      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/diff": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.0.6.tgz",
+      "integrity": "sha512-Atfo14OibSv5wAp4VWNsFYE1AchQRTv9cBGWET4pZWHzYshFSS9NQI6I57rdKn9croWVMbYFbLhJ+yJvmZIIHw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
+    "node_modules/make-error": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/ts-node": {
+      "version": "10.9.2",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
+      "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cspotcode/source-map-support": "^0.8.0",
+        "@tsconfig/node10": "^1.0.7",
+        "@tsconfig/node12": "^1.0.7",
+        "@tsconfig/node14": "^1.0.0",
+        "@tsconfig/node16": "^1.0.2",
+        "acorn": "^8.4.1",
+        "acorn-walk": "^8.1.1",
+        "arg": "^4.1.0",
+        "create-require": "^1.1.0",
+        "diff": "^4.0.1",
+        "make-error": "^1.1.1",
+        "v8-compile-cache-lib": "^3.0.1",
+        "yn": "3.1.1"
+      },
+      "bin": {
+        "ts-node": "dist/bin.js",
+        "ts-node-cwd": "dist/bin-cwd.js",
+        "ts-node-esm": "dist/bin-esm.js",
+        "ts-node-script": "dist/bin-script.js",
+        "ts-node-transpile-only": "dist/bin-transpile.js",
+        "ts-script": "dist/bin-script-deprecated.js"
+      },
+      "peerDependencies": {
+        "@swc/core": ">=1.2.50",
+        "@swc/wasm": ">=1.2.50",
+        "@types/node": "*",
+        "typescript": ">=2.7"
+      },
+      "peerDependenciesMeta": {
+        "@swc/core": {
+          "optional": true
+        },
+        "@swc/wasm": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
+      "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "7.10.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.10.0.tgz",
+      "integrity": "sha512-t5Fy/nfn+14LuOc2KNYg75vZqClpAiqscVvMygNnlsHBFpSXdJaYtXMcdNLpl/Qvc3P2cB3s6lOV51nqsFq4ag==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/v8-compile-cache-lib": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
+      "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/yn": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "libreassistant-mcp",
+  "version": "0.1.0",
+  "type": "module",
+  "scripts": {
+    "test": "node --test --loader ts-node/esm tests/mcp/*.test.ts"
+  },
+  "dependencies": {
+    "ajv": "^8.12.0"
+  },
+  "devDependencies": {
+    "ts-node": "^10.9.1",
+    "typescript": "^5.3.3"
+  }
+}

--- a/servers/echo/index.ts
+++ b/servers/echo/index.ts
@@ -1,0 +1,56 @@
+import { MCPServer, ToolSchema, ResourceSchema, PromptSchema } from '../../src/mcp/types.js';
+import { serveStdio } from '../../src/mcp/transport.js';
+import { fileURLToPath } from 'url';
+
+let lastMessage = '';
+
+const tools: ToolSchema[] = [
+  {
+    name: 'echo_message',
+    description: 'Echoes a message back to the caller',
+    parameters: {
+      type: 'object',
+      properties: {
+        message: { type: 'string', default: '' }
+      },
+      required: []
+    },
+    returns: {
+      type: 'object',
+      properties: {
+        echo: { type: 'string' }
+      },
+      required: ['echo']
+    }
+  }
+];
+
+const resources: ResourceSchema[] = [
+  { uri: 'echo:last_message', description: 'Last echoed message' }
+];
+
+const prompts: PromptSchema[] = [
+  { name: 'echo_template', template: 'Repeat: {{message}}' }
+];
+
+async function invoke(tool: string, params: any) {
+  if (tool === 'echo_message') {
+    lastMessage = params?.message ?? '';
+    return { echo: lastMessage };
+  }
+  throw new Error(`Unknown tool ${tool}`);
+}
+
+const server: MCPServer = {
+  listTools: () => tools,
+  listResources: () => resources,
+  listPrompts: () => prompts,
+  invoke
+};
+
+export default server;
+
+// When executed directly, start a JSON-RPC server over stdio
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  serveStdio(server);
+}

--- a/servers/files/index.ts
+++ b/servers/files/index.ts
@@ -1,0 +1,114 @@
+import { promises as fs } from 'fs';
+import path from 'path';
+import { MCPServer, ToolSchema, ResourceSchema, PromptSchema } from '../../src/mcp/types.js';
+import { serveStdio } from '../../src/mcp/transport.js';
+import { fileURLToPath } from 'url';
+
+const baseDir = path.resolve(process.env.MCP_FS_BASE_DIR || './mcp_fs');
+await fs.mkdir(baseDir, { recursive: true });
+
+const tools: ToolSchema[] = [
+  {
+    name: 'fs_read',
+    description: 'Read a file',
+    parameters: {
+      type: 'object',
+      properties: { path: { type: 'string' } },
+      required: ['path']
+    },
+    returns: { type: 'object', properties: { content: { type: 'string' } }, required: ['content'] }
+  },
+  {
+    name: 'fs_create',
+    description: 'Create a new file',
+    parameters: {
+      type: 'object',
+      properties: { path: { type: 'string' }, content: { type: 'string' } },
+      required: ['path', 'content']
+    },
+    returns: { type: 'object', properties: { status: { enum: ['created'] } }, required: ['status'] }
+  },
+  {
+    name: 'fs_update',
+    description: 'Update an existing file',
+    parameters: {
+      type: 'object',
+      properties: { path: { type: 'string' }, content: { type: 'string' }, confirm: { type: 'boolean' } },
+      required: ['path', 'content', 'confirm']
+    },
+    returns: { type: 'object', properties: { status: { enum: ['updated'] } }, required: ['status'] }
+  },
+  {
+    name: 'fs_delete',
+    description: 'Delete a file',
+    parameters: {
+      type: 'object',
+      properties: { path: { type: 'string' }, confirm: { type: 'boolean' } },
+      required: ['path', 'confirm']
+    },
+    returns: { type: 'object', properties: { status: { enum: ['deleted'] } }, required: ['status'] }
+  },
+  {
+    name: 'fs_list',
+    description: 'List directory entries',
+    parameters: {
+      type: 'object',
+      properties: { path: { type: 'string' } },
+      required: ['path']
+    },
+    returns: { type: 'array', items: { type: 'string' } }
+  }
+];
+
+const resources: ResourceSchema[] = [];
+
+const prompts: PromptSchema[] = [
+  { name: 'file_edit_template', template: 'Update file {{path}} with new content.' }
+];
+
+function resolve(p: string) {
+  const full = path.resolve(baseDir, p);
+  if (!full.startsWith(baseDir)) throw new Error('path outside allowed directory');
+  return full;
+}
+
+async function invoke(tool: string, params: any) {
+  switch (tool) {
+    case 'fs_read': {
+      const content = await fs.readFile(resolve(params.path), 'utf-8');
+      return { content };
+    }
+    case 'fs_create': {
+      await fs.writeFile(resolve(params.path), params.content, { flag: 'wx' });
+      return { status: 'created' };
+    }
+    case 'fs_update': {
+      if (!params.confirm) throw new Error('confirm required');
+      await fs.writeFile(resolve(params.path), params.content, { flag: 'w' });
+      return { status: 'updated' };
+    }
+    case 'fs_delete': {
+      if (!params.confirm) throw new Error('confirm required');
+      await fs.unlink(resolve(params.path));
+      return { status: 'deleted' };
+    }
+    case 'fs_list': {
+      const entries = await fs.readdir(resolve(params.path));
+      return entries;
+    }
+  }
+  throw new Error(`Unknown tool ${tool}`);
+}
+
+const server: MCPServer = {
+  listTools: () => tools,
+  listResources: () => resources,
+  listPrompts: () => prompts,
+  invoke
+};
+
+export default server;
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  serveStdio(server);
+}

--- a/servers/law_by_keystone/index.ts
+++ b/servers/law_by_keystone/index.ts
@@ -1,0 +1,82 @@
+import { promises as fs } from 'fs';
+import path from 'path';
+import { MCPServer, ToolSchema, ResourceSchema, PromptSchema } from '../../src/mcp/types.js';
+import { serveStdio } from '../../src/mcp/transport.js';
+import { fileURLToPath } from 'url';
+
+const baseDir = path.resolve(process.env.MCP_FS_BASE_DIR || './mcp_fs');
+await fs.mkdir(baseDir, { recursive: true });
+
+const tools: ToolSchema[] = [
+  {
+    name: 'generate_legal_summary',
+    description: 'Generate a stub legal research summary and export it',
+    parameters: {
+      type: 'object',
+      properties: {
+        query: { type: 'string' },
+        output_format: { enum: ['md', 'json', 'html'], default: 'md' },
+        output_path: { type: 'string' }
+      },
+      required: ['query', 'output_path']
+    },
+    returns: {
+      type: 'object',
+      properties: { status: { enum: ['exported'] }, path: { type: 'string' } },
+      required: ['status', 'path']
+    }
+  }
+];
+
+const resources: ResourceSchema[] = [
+  { uri: 'law:last_summary', description: 'Last legal summary generated' }
+];
+
+const prompts: PromptSchema[] = [
+  { name: 'legal_research_template', template: 'Research the following query: {{query}}' }
+];
+
+function ensureDir(p: string) {
+  const full = path.resolve(baseDir, p);
+  if (!full.startsWith(baseDir)) throw new Error('path outside allowed directory');
+  return full;
+}
+
+async function invoke(tool: string, params: any) {
+  if (tool !== 'generate_legal_summary') throw new Error(`Unknown tool ${tool}`);
+  const { query, output_format = 'md', output_path } = params;
+  const summary = {
+    query,
+    results: [{ title: 'Example Case', summary: 'No real data fetched' }]
+  };
+  let content: string;
+  let ext: string;
+  if (output_format === 'md') {
+    content = `# Research Summary\n\nQuery: ${query}\n`;
+    ext = 'md';
+  } else if (output_format === 'json') {
+    content = JSON.stringify(summary, null, 2);
+    ext = 'json';
+  } else {
+    content = `<html><body><h1>Research Summary</h1><p>Query: ${query}</p></body></html>`;
+    ext = 'html';
+  }
+  const dir = ensureDir(output_path);
+  await fs.mkdir(dir, { recursive: true });
+  const filePath = path.join(dir, `summary.${ext}`);
+  await fs.writeFile(filePath, content);
+  return { status: 'exported', path: filePath };
+}
+
+const server: MCPServer = {
+  listTools: () => tools,
+  listResources: () => resources,
+  listPrompts: () => prompts,
+  invoke
+};
+
+export default server;
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  serveStdio(server);
+}

--- a/servers/think_tank/index.ts
+++ b/servers/think_tank/index.ts
@@ -1,0 +1,87 @@
+import { MCPServer, ToolSchema, ResourceSchema, PromptSchema } from '../../src/mcp/types.js';
+import { serveStdio } from '../../src/mcp/transport.js';
+import { fileURLToPath } from 'url';
+
+let lastDossier: any = null;
+
+const tools: ToolSchema[] = [
+  {
+    name: 'analyze_goal',
+    description: 'Generate a structured analysis of a goal',
+    parameters: {
+      type: 'object',
+      properties: { goal: { type: 'string' } },
+      required: ['goal']
+    },
+    returns: {
+      type: 'object',
+      properties: {
+        summary: { type: 'string' },
+        analysis: {
+          type: 'object',
+          properties: {
+            goal: { type: 'string' },
+            executive: { type: 'string' },
+            research: { type: 'string' },
+            devils_advocate: { type: 'string' },
+            argument: { type: 'string' },
+            communications: { type: 'string' },
+            visualizer: { type: 'string' }
+          },
+          required: [
+            'goal',
+            'executive',
+            'research',
+            'devils_advocate',
+            'argument',
+            'communications',
+            'visualizer'
+          ]
+        }
+      },
+      required: ['summary', 'analysis']
+    }
+  }
+];
+
+const resources: ResourceSchema[] = [
+  { uri: 'thinktank:last_dossier', description: 'Latest analysis generated' }
+];
+
+const prompts: PromptSchema[] = [
+  { name: 'thinktank_question_template', template: 'Consider the goal: {{goal}}' }
+];
+
+async function invoke(tool: string, params: any) {
+  if (tool !== 'analyze_goal') throw new Error(`Unknown tool ${tool}`);
+  const goal = params.goal;
+  const analysis = {
+    goal,
+    executive: `Breakdown of '${goal}' into manageable tasks.`,
+    research: `Research findings for '${goal}' (stub).`,
+    devils_advocate: `Potential issues with pursuing '${goal}'.`,
+    argument: `Supporting arguments for '${goal}'.`,
+    communications: `Clear and concise explanation of '${goal}'.`,
+    visualizer: 'Visualization not implemented in stub.'
+  };
+  const summary = [
+    analysis.communications,
+    `Argument: ${analysis.argument}`,
+    `Caveats: ${analysis.devils_advocate}`
+  ].join('\n');
+  lastDossier = { summary, analysis };
+  return lastDossier;
+}
+
+const server: MCPServer = {
+  listTools: () => tools,
+  listResources: () => resources,
+  listPrompts: () => prompts,
+  invoke
+};
+
+export default server;
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  serveStdio(server);
+}

--- a/src/libreassistant/main.py
+++ b/src/libreassistant/main.py
@@ -3,11 +3,13 @@
 
 """Application entrypoints and FastAPI app factory."""
 
-from typing import Any, Dict
+from typing import Any, Dict, List
 
 from fastapi import FastAPI, HTTPException, Request
 from fastapi.responses import Response
 from pydantic import BaseModel
+from pathlib import Path
+import json
 
 from .kernel import kernel
 from .plugins import echo, file_io, law_by_keystone, think_tank
@@ -60,6 +62,13 @@ def create_app() -> FastAPI:
 
     vault = DataVault()
 
+    registry_file = Path("config/mcp.registry.json")
+    if registry_file.exists():
+        registry = json.loads(registry_file.read_text())
+        mcp_plugins: List[str] = [s["name"] for s in registry.get("servers", [])]
+    else:  # pragma: no cover - file may be missing in tests
+        mcp_plugins = []
+
     @app.get("/")
     def read_root() -> Dict[str, str]:
         return {"message": "LibreAssistant API"}
@@ -68,6 +77,7 @@ def create_app() -> FastAPI:
         plugin: str
         payload: Dict[str, Any]
         user_id: str
+        granted: bool | None = None
 
     @app.post("/api/v1/invoke")
     def invoke(request: InvokeRequest) -> Dict[str, Any]:
@@ -78,7 +88,10 @@ def create_app() -> FastAPI:
             raise HTTPException(status_code=404, detail="Plugin not found") from exc
         state = kernel.get_state(request.user_id)
         history = state.setdefault("history", [])
-        history.append({"plugin": request.plugin, "payload": request.payload})
+        entry: Dict[str, Any] = {"plugin": request.plugin, "payload": request.payload}
+        if request.granted is not None:
+            entry["granted"] = request.granted
+        history.append(entry)
         return {"result": result, "state": state}
 
     @app.get("/api/v1/history/{user_id}")
@@ -86,6 +99,28 @@ def create_app() -> FastAPI:
         """Retrieve a user's past plugin invocations."""
         state = kernel.get_state(user_id)
         return {"history": state.get("history", [])}
+
+    class HistoryEntry(BaseModel):
+        plugin: str
+        payload: Dict[str, Any]
+        granted: bool
+
+    @app.post("/api/v1/history/{user_id}")
+    def record_history(user_id: str, entry: HistoryEntry) -> Dict[str, str]:
+        state = kernel.get_state(user_id)
+        history = state.setdefault("history", [])
+        history.append(
+            {
+                "plugin": entry.plugin,
+                "payload": entry.payload,
+                "granted": entry.granted,
+            }
+        )
+        return {"status": "ok"}
+
+    @app.get("/api/v1/mcp/plugins")
+    def list_mcp_plugins() -> Dict[str, List[str]]:
+        return {"plugins": mcp_plugins}
 
     class VaultData(BaseModel):
         data: Dict[str, Any]

--- a/src/libreassistant/mcp_adapter.py
+++ b/src/libreassistant/mcp_adapter.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+"""Adapters allowing MCP servers to appear as legacy Plugin objects."""
+
+import json
+import os
+import subprocess
+from pathlib import Path
+from typing import Any, Callable, Dict, Tuple
+
+ROOT = Path(__file__).resolve().parents[2]
+RUNNER = ROOT / "src" / "mcp" / "server-runner.js"
+
+
+class MCPClient:
+    """Minimal JSON-RPC client speaking to an MCP server over stdio."""
+
+    def __init__(self, module: str, env: Dict[str, str] | None = None) -> None:
+        mod_path = Path(module)
+        if not mod_path.is_absolute():
+            mod_path = (ROOT / mod_path).resolve()
+        env_vars = os.environ.copy()
+        if env:
+            env_vars.update(env)
+        self.proc = subprocess.Popen(
+            [
+                "node",
+                "--loader",
+                "ts-node/esm",
+                str(RUNNER),
+                str(mod_path),
+            ],
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            text=True,
+            cwd=str(ROOT),
+            env=env_vars,
+        )
+        self.next_id = 1
+
+        # Perform a basic handshake to ensure the server is ready
+        self.request("listTools")
+
+    def request(self, method: str, params: Any | None = None) -> Any:
+        req = {"jsonrpc": "2.0", "id": self.next_id, "method": method}
+        self.next_id += 1
+        if params is not None:
+            req["params"] = params
+        assert self.proc.stdin and self.proc.stdout
+        self.proc.stdin.write(json.dumps(req) + "\n")
+        self.proc.stdin.flush()
+        line = self.proc.stdout.readline()
+        if not line:
+            raise RuntimeError("no response from MCP server")
+        res = json.loads(line)
+        if "error" in res:
+            raise RuntimeError(res["error"]["message"])
+        return res["result"]
+
+    def invoke(self, tool: str, params: Dict[str, Any]) -> Dict[str, Any]:
+        return self.request("invoke", {"tool": tool, "params": params})
+
+    def close(self) -> None:
+        self.proc.kill()
+
+
+Resolver = Callable[[Dict[str, Any]], Tuple[str, Dict[str, Any]]]
+
+
+class MCPPluginAdapter:
+    """Expose an MCP server as a legacy Plugin object."""
+
+    def __init__(
+        self,
+        module: str,
+        resolver: str | Resolver,
+        env: Dict[str, str] | None = None,
+    ) -> None:
+        self.client = MCPClient(module, env)
+        self.resolver = resolver
+
+    def _resolve(self, payload: Dict[str, Any]) -> Tuple[str, Dict[str, Any]]:
+        if callable(self.resolver):
+            return self.resolver(payload)
+        return self.resolver, payload
+
+    def run(self, user_state: Dict[str, Any], payload: Dict[str, Any]) -> Dict[str, Any]:
+        try:
+            tool, params = self._resolve(payload)
+        except Exception as exc:  # pragma: no cover - defensive
+            return {"error": str(exc)}
+        try:
+            return self.client.invoke(tool, params)
+        except Exception as exc:
+            return {"error": str(exc)}

--- a/src/libreassistant/plugins/echo.py
+++ b/src/libreassistant/plugins/echo.py
@@ -8,15 +8,19 @@ from __future__ import annotations
 from typing import Any, Dict
 
 from ..kernel import kernel
+from ..mcp_adapter import MCPPluginAdapter
 
 
-class EchoPlugin:
-    """Echo back a message while updating user state."""
+class EchoPlugin(MCPPluginAdapter):
+    """Echo back a message while updating user state via MCP server."""
+
+    def __init__(self) -> None:
+        super().__init__("servers/echo/index.ts", "echo_message")
 
     def run(self, user_state: Dict[str, Any], payload: Dict[str, Any]) -> Dict[str, Any]:
-        message = payload.get("message", "")
-        user_state["last_message"] = message
-        return {"echo": message}
+        result = super().run(user_state, payload)
+        user_state["last_message"] = payload.get("message", "")
+        return result
 
 
 def register() -> None:

--- a/src/libreassistant/plugins/file_io.py
+++ b/src/libreassistant/plugins/file_io.py
@@ -6,9 +6,10 @@
 from __future__ import annotations
 
 import os
-from typing import Any, Dict
+from typing import Any, Dict, Tuple
 
 from ..kernel import kernel
+from ..mcp_adapter import MCPPluginAdapter
 
 # Filesystem operations are restricted to this base directory. Paths provided by
 # users will be resolved relative to this directory and rejected if they escape
@@ -16,53 +17,33 @@ from ..kernel import kernel
 ALLOWED_BASE_DIR = os.path.join(os.path.expanduser("~"), "desktop")
 
 
-class FileIOPlugin:
-    """Perform basic file operations with explicit confirmation for risky actions."""
+def _resolver(payload: Dict[str, Any]) -> Tuple[str, Dict[str, Any]]:
+    op = payload.get("operation")
+    mapping = {
+        "read": "fs_read",
+        "create": "fs_create",
+        "update": "fs_update",
+        "delete": "fs_delete",
+        "list": "fs_list",
+    }
+    if op not in mapping:
+        raise ValueError("unknown operation")
+    params = dict(payload)
+    params.pop("operation")
+    return mapping[op], params
+
+
+class FileIOPlugin(MCPPluginAdapter):
+    """Perform basic file operations through the MCP file server."""
+
+    def __init__(self) -> None:
+        env = {"MCP_FS_BASE_DIR": ALLOWED_BASE_DIR}
+        super().__init__("servers/files/index.ts", _resolver, env)
 
     def run(self, user_state: Dict[str, Any], payload: Dict[str, Any]) -> Dict[str, Any]:
-        operation = payload.get("operation")
-        raw_path = payload.get("path")
-        if not operation or not raw_path:
-            return {"error": "operation and path required"}
-
-        allowed_dir = os.path.realpath(os.path.expanduser(ALLOWED_BASE_DIR))
-
-        user_path = os.path.expanduser(raw_path)
-        if not os.path.isabs(user_path):
-            user_path = os.path.join(allowed_dir, user_path)
-        path = os.path.realpath(user_path)
-
-        if not (path == allowed_dir or path.startswith(allowed_dir + os.sep)):
-            return {"error": "path outside allowed directory"}
-
-        user_state["last_file_path"] = path
-
-        confirm = payload.get("confirm", False)
-        content = payload.get("content", "")
-
-        try:
-            if operation == "read":
-                with open(path, "r", encoding="utf-8") as fh:
-                    data = fh.read()
-                return {"content": data}
-            if operation == "create":
-                with open(path, "w", encoding="utf-8") as fh:
-                    fh.write(content)
-                return {"status": "created"}
-            if operation == "update":
-                if not confirm:
-                    return {"error": "explicit confirmation required"}
-                with open(path, "w", encoding="utf-8") as fh:
-                    fh.write(content)
-                return {"status": "updated"}
-            if operation == "delete":
-                if not confirm:
-                    return {"error": "explicit confirmation required"}
-                os.remove(path)
-                return {"status": "deleted"}
-            return {"error": "unknown operation"}
-        except OSError as exc:  # pragma: no cover - error branch
-            return {"error": str(exc)}
+        if "path" in payload:
+            user_state["last_file_path"] = os.path.realpath(payload["path"])
+        return super().run(user_state, payload)
 
 
 def register() -> None:

--- a/src/libreassistant/plugins/law_by_keystone.py
+++ b/src/libreassistant/plugins/law_by_keystone.py
@@ -5,67 +5,19 @@
 
 from __future__ import annotations
 
-import json
-import os
 from typing import Any, Dict
 
 from ..kernel import kernel
+from ..mcp_adapter import MCPPluginAdapter
 from . import file_io
 
 
-class LawByKeystonePlugin:
-    """Export legal research results to the local filesystem."""
+class LawByKeystonePlugin(MCPPluginAdapter):
+    """Export legal research results via the MCP law server."""
 
-    def run(self, user_state: Dict[str, Any], payload: Dict[str, Any]) -> Dict[str, Any]:
-        query = payload.get("query")
-        fmt = payload.get("output_format", "md")
-        output_path = payload.get("output_path")
-        if not query or not output_path:
-            return {"error": "query and output_path required"}
-
-        if fmt not in {"md", "json", "html"}:
-            return {"error": "unsupported format"}
-
-        allowed_dir = os.path.realpath(os.path.expanduser(file_io.ALLOWED_BASE_DIR))
-        user_path = os.path.expanduser(output_path)
-        if not os.path.isabs(user_path):
-            user_path = os.path.join(allowed_dir, user_path)
-        output_dir = os.path.realpath(user_path)
-
-        if not (output_dir == allowed_dir or output_dir.startswith(allowed_dir + os.sep)):
-            return {"error": "path outside allowed directory"}
-
-        os.makedirs(output_dir, exist_ok=True)
-
-        summary = {
-            "query": query,
-            "results": [
-                {"title": "Example Case", "summary": "No real data fetched"}
-            ],
-        }
-
-        if fmt == "md":
-            content = f"# Research Summary\n\nQuery: {query}\n"
-            ext = "md"
-        elif fmt == "json":
-            content = json.dumps(summary, indent=2)
-            ext = "json"
-        else:  # html
-            content = (
-                "<html><body><h1>Research Summary</h1>"
-                f"<p>Query: {query}</p></body></html>"
-            )
-            ext = "html"
-
-        file_path = os.path.join(output_dir, f"summary.{ext}")
-        file_plugin = file_io.FileIOPlugin()
-        result = file_plugin.run(
-            user_state,
-            {"operation": "create", "path": file_path, "content": content},
-        )
-        if "error" in result:
-            return result
-        return {"status": "exported", "path": file_path}
+    def __init__(self) -> None:
+        env = {"MCP_FS_BASE_DIR": file_io.ALLOWED_BASE_DIR}
+        super().__init__("servers/law_by_keystone/index.ts", "generate_legal_summary", env)
 
 
 def register() -> None:

--- a/src/libreassistant/plugins/think_tank.py
+++ b/src/libreassistant/plugins/think_tank.py
@@ -8,39 +8,21 @@ from __future__ import annotations
 from typing import Any, Dict
 
 from ..kernel import kernel
-from ..experts import (
-    argumentation,
-    communications,
-    devils_advocate,
-    executive,
-    research,
-    visualizer,
-    aggregation,
-)
+from ..mcp_adapter import MCPPluginAdapter
 
 
-class ThinkTankPlugin:
-    """Orchestrate specialist agents to deliver a polished answer."""
+class ThinkTankPlugin(MCPPluginAdapter):
+    """Orchestrate specialist agents via the MCP ThinkTank server."""
+
+    def __init__(self) -> None:
+        super().__init__("servers/think_tank/index.ts", "analyze_goal")
 
     def run(self, user_state: Dict[str, Any], payload: Dict[str, Any]) -> Dict[str, Any]:
-        goal = payload.get("goal") or payload.get("question")
-        if not goal:
-            return {"error": "goal required"}
-
-        analysis = {
-            "goal": goal,
-            "executive": executive.analyze(goal),
-            "research": research.analyze(goal),
-            "devils_advocate": devils_advocate.analyze(goal),
-            "argument": argumentation.analyze(goal),
-            "communications": communications.analyze(goal),
-            "visualizer": visualizer.analyze(goal),
-        }
-        dossier = user_state.setdefault("thinktank_dossier", [])
-        dossier.append(analysis)
-        summary = aggregation.summarize(analysis)
-
-        return {"summary": summary, "analysis": analysis}
+        result = super().run(user_state, payload)
+        if "analysis" in result:
+            dossier = user_state.setdefault("thinktank_dossier", [])
+            dossier.append(result["analysis"])
+        return result
 
 
 def register() -> None:

--- a/src/mcp/client.ts
+++ b/src/mcp/client.ts
@@ -1,0 +1,163 @@
+import { createHash } from 'crypto';
+import Ajv, { ValidateFunction } from 'ajv';
+import { MCPServer, AuditEntry } from './types.js';
+import { Transport } from './transport.js';
+import fs from 'fs/promises';
+import path from 'path';
+
+const MAX_LOG_SIZE = 5 * 1024 * 1024; // 5MB
+
+// Wrapper around a remote MCP server accessed via a Transport.
+class RemoteServer implements MCPServer {
+  constructor(
+    private transport: Transport,
+    private cachedTools: any[],
+    private cachedResources: any[],
+    private cachedPrompts: any[],
+    private validators: Map<string, ValidateFunction>
+  ) {}
+
+  listTools() {
+    return this.cachedTools;
+  }
+
+  listResources() {
+    return this.cachedResources;
+  }
+
+  listPrompts() {
+    return this.cachedPrompts;
+  }
+
+  async invoke(tool: string, params: any) {
+    const validator = this.validators.get(tool);
+    const args = params ?? {};
+    if (validator && !validator(args)) {
+      return { error: 'ValidationError', details: validator.errors };
+    }
+    return this.transport.request('invoke', { tool, params: args });
+  }
+}
+
+// Client that connects to MCP servers via JSON-RPC transports.
+export class MCPClient {
+  private servers: Map<string, RemoteServer> = new Map();
+  private transports: Map<string, Transport> = new Map();
+  public auditLog: AuditEntry[] = [];
+  private ajv = new Ajv({ useDefaults: true });
+  private static allowedHosts: Set<string> = new Set();
+  private static fetchPatched = false;
+  private logPath = path.resolve('logs/audit.ndjson');
+
+  async register(name: string, transport: Transport) {
+    const tools = await transport.request('listTools');
+    const resources = await transport.request('listResources');
+    const prompts = await transport.request('listPrompts');
+    const validators = new Map<string, ValidateFunction>();
+    for (const t of tools) {
+      if (t.parameters) {
+        validators.set(t.name, this.ajv.compile(t.parameters));
+      }
+    }
+    const server = new RemoteServer(transport, tools, resources, prompts, validators);
+    this.servers.set(name, server);
+    this.transports.set(name, transport);
+  }
+
+  listServers() {
+    return Array.from(this.servers.keys());
+  }
+
+  getServer(name: string): MCPServer {
+    const server = this.servers.get(name);
+    if (!server) throw new Error(`Unknown server ${name}`);
+    return server;
+  }
+
+  async invoke(serverName: string, tool: string, params: any) {
+    const server = this.getServer(serverName);
+    let beforeHash: string | undefined;
+    let afterHash: string | undefined;
+
+    // For file operations we capture before/after hashes if path provided
+    if (params && params.path && typeof params.path === 'string') {
+      try {
+        const before = await import('fs/promises').then(fs => fs.readFile(params.path));
+        beforeHash = createHash('sha256').update(before).digest('hex');
+      } catch {
+        // ignore if file doesn't exist
+      }
+    }
+
+    const result = await server.invoke(tool, params);
+
+    if (params && params.path && typeof params.path === 'string') {
+      try {
+        const after = await import('fs/promises').then(fs => fs.readFile(params.path));
+        afterHash = createHash('sha256').update(after).digest('hex');
+      } catch {
+        // ignore
+      }
+    }
+
+    const entry: AuditEntry = {
+      server: serverName,
+      tool,
+      params,
+      result,
+      timestamp: Date.now(),
+      beforeHash,
+      afterHash,
+    };
+    this.auditLog.push(entry);
+    await this.appendAudit(entry);
+    return result;
+  }
+
+  private async appendAudit(entry: AuditEntry) {
+    try {
+      await fs.mkdir(path.dirname(this.logPath), { recursive: true });
+      try {
+        const stats = await fs.stat(this.logPath);
+        if (stats.size > MAX_LOG_SIZE) {
+          await fs.rename(this.logPath, this.logPath + '.1');
+        }
+      } catch {
+        // file doesn't exist yet
+      }
+      await fs.appendFile(this.logPath, JSON.stringify(entry) + '\n');
+    } catch (err) {
+      console.error('Failed to write audit log', err);
+    }
+  }
+
+  close() {
+    for (const transport of this.transports.values()) {
+      transport.close();
+    }
+  }
+
+  setAllowedHosts(hosts: string[]) {
+    MCPClient.allowedHosts = new Set(hosts);
+    if (!MCPClient.fetchPatched) {
+      const original = globalThis.fetch.bind(globalThis);
+      globalThis.fetch = async function (input: any, init?: any) {
+        const href =
+          typeof input === 'string'
+            ? input
+            : input instanceof URL
+            ? input.href
+            : input.url;
+        const host = new URL(href).hostname;
+        if (
+          MCPClient.allowedHosts.size &&
+          !MCPClient.allowedHosts.has(host)
+        ) {
+          return Promise.reject(new Error(`Host ${host} not allowed`));
+        }
+        return original(input as any, init);
+      } as any;
+      MCPClient.fetchPatched = true;
+    }
+  }
+}

--- a/src/mcp/registry.ts
+++ b/src/mcp/registry.ts
@@ -1,0 +1,31 @@
+import { MCPClient } from './client.js';
+import { StdioTransport } from './transport.js';
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+interface RegistryConfig {
+  servers: { name: string; module: string }[];
+  allowedHosts?: string[];
+}
+
+export async function loadRegistry(configPath: string, client: MCPClient) {
+  const config: RegistryConfig = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
+  const runner = path.resolve(
+    path.dirname(fileURLToPath(import.meta.url)),
+    'server-runner.js'
+  );
+  if (config.allowedHosts) {
+    client.setAllowedHosts(config.allowedHosts);
+  }
+  for (const entry of config.servers) {
+    const modulePath = path.resolve(entry.module);
+    const transport = new StdioTransport('node', [
+      '--loader',
+      'ts-node/esm',
+      runner,
+      modulePath,
+    ]);
+    await client.register(entry.name, transport);
+  }
+}

--- a/src/mcp/server-runner.js
+++ b/src/mcp/server-runner.js
@@ -1,0 +1,14 @@
+import { serveStdio } from './transport.ts';
+import { fileURLToPath, pathToFileURL } from 'url';
+import path from 'path';
+
+const modArg = process.argv[2];
+if (!modArg) {
+  console.error('No module provided');
+  process.exit(1);
+}
+const modulePath = path.resolve(modArg);
+
+const mod = await import(pathToFileURL(modulePath).href);
+const server = mod.default;
+serveStdio(server);

--- a/src/mcp/transport.ts
+++ b/src/mcp/transport.ts
@@ -1,0 +1,176 @@
+import { spawn, ChildProcess } from 'child_process';
+import { MCPServer } from './types.js';
+
+// Basic JSON-RPC message types
+interface JSONRPCRequest {
+  jsonrpc: '2.0';
+  id: number;
+  method: string;
+  params?: any;
+}
+
+interface JSONRPCResponse {
+  jsonrpc: '2.0';
+  id: number;
+  result?: any;
+  error?: { code: number; message: string; data?: any };
+}
+
+// Transport interface used by the MCP client
+export interface Transport {
+  request(method: string, params?: any): Promise<any>;
+  close(): void;
+}
+
+// JSON-RPC over child-process stdio
+export class StdioTransport implements Transport {
+  private proc: ChildProcess;
+  private nextId = 1;
+  private pending = new Map<
+    number,
+    { resolve: (v: any) => void; reject: (err: any) => void }
+  >();
+  private buffer = '';
+
+  constructor(command: string, args: string[] = []) {
+    this.proc = spawn(command, args, { stdio: ['pipe', 'pipe', 'inherit'] });
+    this.proc.stdout!.setEncoding('utf8');
+    this.proc.stdout!.on('data', chunk => {
+      this.buffer += chunk;
+      const parts = this.buffer.split('\n');
+      this.buffer = parts.pop()!;
+      for (const part of parts) {
+        if (!part.trim()) continue;
+        let msg: JSONRPCResponse;
+        try {
+          msg = JSON.parse(part);
+        } catch {
+          continue;
+        }
+        const pending = this.pending.get(msg.id);
+        if (!pending) continue;
+        this.pending.delete(msg.id);
+        if (msg.error) pending.reject(new Error(msg.error.message));
+        else pending.resolve(msg.result);
+      }
+    });
+  }
+
+  request(method: string, params?: any): Promise<any> {
+    const id = this.nextId++;
+    const req: JSONRPCRequest = { jsonrpc: '2.0', id, method, params };
+    this.proc.stdin!.write(JSON.stringify(req) + '\n');
+    return new Promise((resolve, reject) => {
+      this.pending.set(id, { resolve, reject });
+    });
+  }
+
+  close() {
+    this.proc.kill();
+  }
+}
+
+// JSON-RPC over simple HTTP POST + optional SSE stream
+export class HTTPTransport implements Transport {
+  private abort?: AbortController;
+  constructor(private endpoint: string, private sseEndpoint?: string) {
+    if (sseEndpoint) {
+      this.abort = new AbortController();
+      fetch(sseEndpoint, {
+        headers: { Accept: 'text/event-stream' },
+        signal: this.abort.signal,
+      }).then(async res => {
+        // Naive SSE parser for notifications
+        const reader = res.body?.getReader();
+        if (!reader) return;
+        const decoder = new TextDecoder();
+        let buf = '';
+        while (true) {
+          const { value, done } = await reader.read();
+          if (done) break;
+          buf += decoder.decode(value, { stream: true });
+          const parts = buf.split('\n\n');
+          buf = parts.pop()!;
+          for (const part of parts) {
+            const line = part.split('\n').find(l => l.startsWith('data:'));
+            if (!line) continue;
+            try {
+              const msg = JSON.parse(line.slice(5));
+              // notifications are ignored for now
+            } catch {
+              /* ignore */
+            }
+          }
+        }
+      });
+    }
+  }
+
+  async request(method: string, params?: any): Promise<any> {
+    const res = await fetch(this.endpoint, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ jsonrpc: '2.0', id: 1, method, params }),
+    });
+    const json = await res.json();
+    if (json.error) throw new Error(json.error.message);
+    return json.result;
+  }
+
+  close() {
+    this.abort?.abort();
+  }
+}
+
+// Utility to serve an MCPServer over stdio
+export function serveStdio(server: MCPServer) {
+  process.stdin.setEncoding('utf8');
+  let buffer = '';
+  process.stdin.on('data', chunk => {
+    buffer += chunk;
+    const parts = buffer.split('\n');
+    buffer = parts.pop()!;
+    for (const part of parts) {
+      if (!part.trim()) continue;
+      let req: JSONRPCRequest;
+      try {
+        req = JSON.parse(part);
+      } catch {
+        continue;
+      }
+      handle(req);
+    }
+  });
+
+  async function handle(req: JSONRPCRequest) {
+    try {
+      let result;
+      switch (req.method) {
+        case 'listTools':
+          result = server.listTools();
+          break;
+        case 'listResources':
+          result = server.listResources();
+          break;
+        case 'listPrompts':
+          result = server.listPrompts();
+          break;
+        case 'invoke':
+          result = await server.invoke(req.params.tool, req.params.params ?? req.params);
+          break;
+        default:
+          throw new Error(`Unknown method ${req.method}`);
+      }
+      const res: JSONRPCResponse = { jsonrpc: '2.0', id: req.id, result };
+      process.stdout.write(JSON.stringify(res) + '\n');
+    } catch (err: any) {
+      const res: JSONRPCResponse = {
+        jsonrpc: '2.0',
+        id: req.id,
+        error: { code: -32000, message: err.message },
+      };
+      process.stdout.write(JSON.stringify(res) + '\n');
+    }
+  }
+}
+

--- a/src/mcp/types.ts
+++ b/src/mcp/types.ts
@@ -1,0 +1,34 @@
+// Basic types for Model Context Protocol objects
+export interface ToolSchema {
+  name: string;
+  description: string;
+  parameters: Record<string, unknown>; // JSON Schema
+  returns: Record<string, unknown>; // JSON Schema
+}
+
+export interface ResourceSchema {
+  uri: string;
+  description: string;
+}
+
+export interface PromptSchema {
+  name: string;
+  template: string;
+}
+
+export interface MCPServer {
+  listTools(): ToolSchema[];
+  listResources(): ResourceSchema[];
+  listPrompts(): PromptSchema[];
+  invoke(tool: string, params: any): Promise<any>;
+}
+
+export interface AuditEntry {
+  server: string;
+  tool: string;
+  params: any;
+  result: any;
+  timestamp: number;
+  beforeHash?: string;
+  afterHash?: string;
+}

--- a/src/switchboard/mcpAdapter.ts
+++ b/src/switchboard/mcpAdapter.ts
@@ -1,0 +1,75 @@
+import { MCPClient } from '../mcp/client.js';
+
+// Adapter that exposes MCP servers as high level "plugins" to the UI.
+// Each plugin maps to a primary tool; the underlying tools/resources/prompts
+// remain hidden from the switchboard.
+export class MCPAdapter {
+  private toolMap: Record<string, string | ((params: any) => string)> = {
+    echo: 'echo_message',
+    files: (params: any) => {
+      const op = params?.operation;
+      const mapping: Record<string, string> = {
+        read: 'fs_read',
+        create: 'fs_create',
+        update: 'fs_update',
+        delete: 'fs_delete',
+        list: 'fs_list',
+      };
+      return mapping[op];
+    },
+    law_by_keystone: 'generate_legal_summary',
+    think_tank: 'analyze_goal',
+  };
+
+  constructor(private client: MCPClient) {}
+
+  listPlugins(): string[] {
+    return Object.keys(this.toolMap);
+  }
+
+  async invokePlugin(plugin: string, params: any, userId: string): Promise<any> {
+    const mapping = this.toolMap[plugin];
+    if (!mapping) throw new Error(`Unknown plugin ${plugin}`);
+    const tool = typeof mapping === 'function' ? mapping(params) : mapping;
+    if (!tool) throw new Error(`Unknown operation for plugin ${plugin}`);
+
+    let granted = true;
+    // Prompt for confirmation on destructive file operations
+    if (
+      plugin === 'files' &&
+      (tool === 'fs_update' || tool === 'fs_delete') &&
+      !params.confirm
+    ) {
+      const ask = (globalThis as any).showConsentModal
+        ? (msg: string) => (globalThis as any).showConsentModal(msg)
+        : async () => true;
+      granted = await ask(`Allow ${tool} on ${params.path}?`);
+      params.confirm = granted;
+      if (!granted) {
+        await this.recordHistory(userId, plugin, params, false);
+        return { error: 'PermissionDenied' };
+      }
+    }
+
+    const result = await this.client.invoke(plugin, tool, params);
+    await this.recordHistory(userId, plugin, params, granted);
+    return result;
+  }
+
+  private async recordHistory(
+    user: string,
+    plugin: string,
+    payload: any,
+    granted: boolean,
+  ) {
+    try {
+      await fetch(`/api/v1/history/${user}`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ plugin, payload, granted }),
+      });
+    } catch {
+      /* ignore logging failures */
+    }
+  }
+}

--- a/tests/mcp/audit.test.ts
+++ b/tests/mcp/audit.test.ts
@@ -1,0 +1,31 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { MCPClient } from '../../src/mcp/client.js';
+import { loadRegistry } from '../../src/mcp/registry.js';
+import path from 'path';
+import fs from 'fs';
+
+async function setup() {
+  const client = new MCPClient();
+  await loadRegistry(path.resolve('config/mcp.registry.json'), client);
+  return client;
+}
+
+test('audit log records invocations', async () => {
+  const client = await setup();
+  try {
+    await client.invoke('echo', 'echo_message', { message: 'hi' });
+    assert.equal(client.auditLog.length, 1);
+    const logPath = path.resolve('logs/audit.ndjson');
+    assert.ok(fs.existsSync(logPath));
+    const lines = fs
+      .readFileSync(logPath, 'utf8')
+      .trim()
+      .split('\n')
+      .filter(Boolean)
+      .map((l) => JSON.parse(l));
+    assert.ok(lines.some((e) => e.tool === 'echo_message'));
+  } finally {
+    client.close();
+  }
+});

--- a/tests/mcp/files.test.ts
+++ b/tests/mcp/files.test.ts
@@ -1,0 +1,48 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { MCPClient } from '../../src/mcp/client.js';
+import { loadRegistry } from '../../src/mcp/registry.js';
+import path from 'path';
+
+async function setup() {
+  const client = new MCPClient();
+  await loadRegistry(path.resolve('config/mcp.registry.json'), client);
+  return client;
+}
+
+test('file CRUD operations', async () => {
+  const client = await setup();
+  try {
+    const file = 'crud.txt';
+    const dir = '.';
+    await client.invoke('files', 'fs_create', { path: file, content: 'hello' });
+    const read1 = await client.invoke('files', 'fs_read', { path: file });
+    assert.equal(read1.content, 'hello');
+    await client.invoke('files', 'fs_update', { path: file, content: 'world', confirm: true });
+    const read2 = await client.invoke('files', 'fs_read', { path: file });
+    assert.equal(read2.content, 'world');
+    const list = await client.invoke('files', 'fs_list', { path: dir });
+    assert.ok(Array.isArray(list));
+    await client.invoke('files', 'fs_delete', { path: file, confirm: true });
+  } finally {
+    client.close();
+  }
+});
+
+test('refuses destructive operations without confirm', async () => {
+  const client = await setup();
+  try {
+    const file = 'consent.txt';
+    await client.invoke('files', 'fs_create', { path: file, content: 'hi' });
+    const update = await client.invoke('files', 'fs_update', {
+      path: file,
+      content: 'bye'
+    });
+    assert.equal(update.error, 'ValidationError');
+    const del = await client.invoke('files', 'fs_delete', { path: file });
+    assert.equal(del.error, 'ValidationError');
+    await client.invoke('files', 'fs_delete', { path: file, confirm: true });
+  } finally {
+    client.close();
+  }
+});

--- a/tests/mcp/handshake.test.ts
+++ b/tests/mcp/handshake.test.ts
@@ -1,0 +1,25 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { MCPClient } from '../../src/mcp/client.js';
+import { loadRegistry } from '../../src/mcp/registry.js';
+import path from 'path';
+
+async function setup() {
+  const client = new MCPClient();
+  await loadRegistry(path.resolve('config/mcp.registry.json'), client);
+  return client;
+}
+
+test('servers expose tools', async () => {
+  const client = await setup();
+  try {
+    const servers = client.listServers();
+    assert.deepEqual(servers.sort(), ['echo','files','law_by_keystone','think_tank']);
+    for (const name of servers) {
+      const server = client.getServer(name);
+      assert.ok(server.listTools().length > 0);
+    }
+  } finally {
+    client.close();
+  }
+});

--- a/tests/mcp/law.test.ts
+++ b/tests/mcp/law.test.ts
@@ -1,0 +1,23 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { MCPClient } from '../../src/mcp/client.js';
+import { loadRegistry } from '../../src/mcp/registry.js';
+import path from 'path';
+import fs from 'fs';
+
+async function setup() {
+  const client = new MCPClient();
+  await loadRegistry(path.resolve('config/mcp.registry.json'), client);
+  return client;
+}
+
+test('law summary generation', async () => {
+  const client = await setup();
+  try {
+    const res = await client.invoke('law_by_keystone', 'generate_legal_summary', { query: 'test', output_format: 'md', output_path: 'law' });
+    assert.equal(res.status, 'exported');
+    assert.ok(fs.existsSync(res.path));
+  } finally {
+    client.close();
+  }
+});

--- a/tests/mcp/network.test.ts
+++ b/tests/mcp/network.test.ts
@@ -1,0 +1,11 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { MCPClient } from '../../src/mcp/client.js';
+
+test('blocks disallowed network hosts', async () => {
+  const client = new MCPClient();
+  client.setAllowedHosts(['example.com']);
+  await assert.rejects(() => fetch('https://notexample.com'), /not allowed/);
+  client.setAllowedHosts([]); // reset allowlist
+  client.close();
+});

--- a/tests/mcp/think_tank.test.ts
+++ b/tests/mcp/think_tank.test.ts
@@ -1,0 +1,22 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { MCPClient } from '../../src/mcp/client.js';
+import { loadRegistry } from '../../src/mcp/registry.js';
+import path from 'path';
+
+async function setup() {
+  const client = new MCPClient();
+  await loadRegistry(path.resolve('config/mcp.registry.json'), client);
+  return client;
+}
+
+test('think tank returns structured analysis', async () => {
+  const client = await setup();
+  try {
+    const res = await client.invoke('think_tank', 'analyze_goal', { goal: 'world peace' });
+    assert.equal(res.analysis.goal, 'world peace');
+    assert.ok(res.summary);
+  } finally {
+    client.close();
+  }
+});

--- a/tests/mcp/validation.test.ts
+++ b/tests/mcp/validation.test.ts
@@ -1,0 +1,22 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import path from 'path';
+import { MCPClient } from '../../src/mcp/client.js';
+import { loadRegistry } from '../../src/mcp/registry.js';
+
+async function setup() {
+  const client = new MCPClient();
+  await loadRegistry(path.resolve('config/mcp.registry.json'), client);
+  return client;
+}
+
+test('rejects params that do not match schema', async () => {
+  const client = await setup();
+  try {
+    const res = await client.invoke('echo', 'echo_message', { message: 123 });
+    assert.equal(res.error, 'ValidationError');
+    assert.ok(Array.isArray(res.details));
+  } finally {
+    client.close();
+  }
+});

--- a/tests/test_history_record.py
+++ b/tests/test_history_record.py
@@ -1,0 +1,11 @@
+"""Tests for recording history entries explicitly."""
+
+
+def test_record_history_endpoint(client) -> None:
+    response = client.post(
+        "/api/v1/history/alice",
+        json={"plugin": "echo", "payload": {"message": "hi"}, "granted": True},
+    )
+    assert response.status_code == 200
+    hist = client.get("/api/v1/history/alice").json()["history"]
+    assert hist[-1] == {"plugin": "echo", "payload": {"message": "hi"}, "granted": True}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ES2022",
+    "moduleResolution": "node",
+    "outDir": "dist",
+    "esModuleInterop": true,
+    "strict": true,
+    "skipLibCheck": true
+  },
+  "include": ["src", "servers", "tests"]
+}

--- a/ui/components/confirm-dialog.js
+++ b/ui/components/confirm-dialog.js
@@ -1,0 +1,34 @@
+// Copyright (c) 2024 LibreAssistant contributors.
+// Licensed under the MIT License.
+
+// Utility to show a confirmation modal using <la-modal-dialog>.
+// Returns a Promise<boolean> that resolves to true when the user confirms.
+
+window.showConsentModal = function (message) {
+  return new Promise(resolve => {
+    const dialog = document.createElement('la-modal-dialog');
+    dialog.innerHTML = `
+      <span slot="title">Confirm</span>
+      <p>${message}</p>
+      <div style="margin-top: var(--spacing-md); display:flex; justify-content:flex-end; gap: var(--spacing-sm);">
+        <button id="cancel">Cancel</button>
+        <button id="ok">OK</button>
+      </div>
+    `;
+    const cleanup = (result) => {
+      resolve(result);
+      dialog.remove();
+    };
+    dialog.addEventListener('keydown', e => {
+      if (e.key === 'Escape') cleanup(false);
+    });
+    dialog.shadowRoot.querySelector('.backdrop').addEventListener('click', () => cleanup(false));
+    dialog.shadowRoot.querySelector('.close').addEventListener('click', () => cleanup(false));
+    dialog.querySelector('#cancel').addEventListener('click', () => cleanup(false));
+    dialog.querySelector('#ok').addEventListener('click', () => cleanup(true));
+    document.body.appendChild(dialog);
+    dialog.setAttribute('open', '');
+  });
+};
+
+export {};

--- a/ui/components/index.js
+++ b/ui/components/index.js
@@ -5,6 +5,7 @@ import './primary-button.js';
 import './input-field.js';
 import './information-card.js';
 import './modal-dialog.js';
+import './confirm-dialog.js';
 import './main-tabs.js';
 import './onboarding-flow.js';
 import './switchboard.js';

--- a/ui/components/plugin-catalogue.js
+++ b/ui/components/plugin-catalogue.js
@@ -45,23 +45,26 @@ class LAPluginCatalogue extends HTMLElement {
       </header>
       <ul id="list"></ul>
     `;
-    this.plugins = [
-      { name: 'Weather', enabled: false },
-      { name: 'Calculator', enabled: false },
-      { name: 'Notes', enabled: false },
-      { name: 'Calendar', enabled: false },
-      { name: 'File I/O', enabled: false },
-      { name: 'Law by Keystone', enabled: false },
-      { name: 'ThinkTank', enabled: false },
-    ];
+    this.plugins = [];
   }
 
-  connectedCallback() {
+  async connectedCallback() {
+    await this.loadPlugins();
     this.render();
     const search = this.shadowRoot.getElementById('search');
     search.shadowRoot.querySelector('input').addEventListener('input', e => {
       this.filter(e.target.value);
     });
+  }
+
+  async loadPlugins() {
+    try {
+      const res = await fetch('/api/v1/mcp/plugins');
+      const data = await res.json();
+      this.plugins = data.plugins.map(name => ({ name, enabled: false }));
+    } catch {
+      this.plugins = [];
+    }
   }
 
   filter(query) {


### PR DESCRIPTION
## Summary
- ensure GitHub Actions runs MCP tests by installing Node 20, running `npm ci`, and invoking both JS and Python suites
- verify destructive file operations require explicit confirmation before execution

## Testing
- `npm test`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a495a095d48332acb083ebc9a1f87d