### PR TITLE
Ensure MCP plugins close clients on shutdown

### DIFF
--- a/src/libreassistant/kernel.py
+++ b/src/libreassistant/kernel.py
@@ -43,5 +43,15 @@ class Microkernel:
         self._plugins.clear()
         self._states.clear()
 
+    def shutdown(self) -> None:
+        """Call any cleanup hooks exposed by registered plugins."""
+        for plugin in self._plugins.values():
+            close = getattr(plugin, "close", None)
+            if callable(close):
+                try:
+                    close()
+                except Exception:  # pragma: no cover - best effort cleanup
+                    pass
+
 
 kernel = Microkernel()

--- a/src/libreassistant/main.py
+++ b/src/libreassistant/main.py
@@ -62,6 +62,10 @@ def create_app() -> FastAPI:
 
     vault = DataVault()
 
+    @app.on_event("shutdown")
+    def _cleanup_plugins() -> None:
+        kernel.shutdown()
+
     registry_file = Path("config/mcp.registry.json")
     if registry_file.exists():
         registry = json.loads(registry_file.read_text())

--- a/src/libreassistant/mcp_adapter.py
+++ b/src/libreassistant/mcp_adapter.py
@@ -79,6 +79,16 @@ class MCPPluginAdapter:
         self.client = MCPClient(module, env)
         self.resolver = resolver
 
+    def close(self) -> None:
+        """Release resources held by the underlying MCP client."""
+        self.client.close()
+
+    def __del__(self) -> None:  # pragma: no cover - best effort cleanup
+        try:
+            self.close()
+        except Exception:
+            pass
+
     def _resolve(self, payload: Dict[str, Any]) -> Tuple[str, Dict[str, Any]]:
         if callable(self.resolver):
             return self.resolver(payload)


### PR DESCRIPTION
## Summary
- add cleanup hook to `MCPPluginAdapter` to close its MCP client
- teach microkernel to call plugin `close` hooks
- invoke plugin cleanup during FastAPI shutdown

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a534ca32bc8332a0dad0a4c47c7bf1