### PR TITLE
chore: remove unused typing imports

### DIFF
--- a/src/libreassistant/plugins/law_by_keystone.py
+++ b/src/libreassistant/plugins/law_by_keystone.py
@@ -5,8 +5,6 @@
 
 from __future__ import annotations
 
-from typing import Any, Dict
-
 from ..kernel import kernel
 from ..mcp_adapter import MCPPluginAdapter
 from . import file_io


### PR DESCRIPTION
## Summary
- tidy law_by_keystone plugin by removing unused Any/Dict imports

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a5518a5ba08332b382aa548b7e1a02