### PR TITLE
Validate file paths within allowed directory

### DIFF
--- a/src/libreassistant/plugins/file_io.py
+++ b/src/libreassistant/plugins/file_io.py
@@ -42,7 +42,15 @@ class FileIOPlugin(MCPPluginAdapter):
 
     def run(self, user_state: Dict[str, Any], payload: Dict[str, Any]) -> Dict[str, Any]:
         if "path" in payload:
-            user_state["last_file_path"] = os.path.realpath(payload["path"])
+            # Resolve the path to its canonical form and ensure it remains within the
+            # allowed base directory. The resolved path is stored in ``user_state``
+            # and passed on to the server to prevent path traversal attacks.
+            resolved_path = os.path.realpath(payload["path"])
+            base_dir = os.path.realpath(ALLOWED_BASE_DIR)
+            if os.path.commonpath([resolved_path, base_dir]) != base_dir:
+                return {"error": "path outside allowed directory"}
+            user_state["last_file_path"] = resolved_path
+            payload["path"] = resolved_path
         return super().run(user_state, payload)
 
 

--- a/tests/test_file_io_plugin.py
+++ b/tests/test_file_io_plugin.py
@@ -31,6 +31,24 @@ def test_file_io_plugin_unit(tmp_path: Path) -> None:
     assert result == {"error": "path outside allowed directory"}
 
 
+def test_file_io_plugin_path_sanitization(tmp_path: Path) -> None:
+    file_io.ALLOWED_BASE_DIR = str(tmp_path)
+    plugin = FileIOPlugin()
+    state: dict[str, Any] = {}
+
+    # Path that includes traversal but stays within the allowed directory
+    inside = tmp_path / "folder" / ".." / "sanitized.txt"
+    result = plugin.run(state, {"operation": "create", "path": str(inside), "content": "hi"})
+    assert result == {"status": "created"}
+    assert state["last_file_path"] == str(tmp_path / "sanitized.txt")
+
+    # Path that escapes the allowed directory is rejected and does not update state
+    outside = tmp_path.parent / "other.txt"
+    result = plugin.run(state, {"operation": "read", "path": str(outside)})
+    assert result == {"error": "path outside allowed directory"}
+    assert state["last_file_path"] == str(tmp_path / "sanitized.txt")
+
+
 def test_file_io_plugin_integration(client, tmp_path: Path) -> None:
     file_io.ALLOWED_BASE_DIR = str(tmp_path)
     file_io.register()


### PR DESCRIPTION
## Summary
- ensure `FileIOPlugin.run` only stores paths rooted in `ALLOWED_BASE_DIR`
- add tests covering path sanitization and rejection of disallowed paths

## Testing
- `python -m pytest tests/test_file_io_plugin.py -q`
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a551833eec833290cd5541d363b636