### PR TITLE
Validate plugin payloads with Pydantic models

### DIFF
--- a/src/libreassistant/kernel.py
+++ b/src/libreassistant/kernel.py
@@ -7,6 +7,8 @@ from __future__ import annotations
 
 from typing import Any, Dict, Protocol
 
+from pydantic import BaseModel, ValidationError
+
 
 class Plugin(Protocol):
     """Protocol that all plugins must implement."""
@@ -40,6 +42,12 @@ class Microkernel:
         if plugin is None:
             raise KeyError(name)
         state = self.get_state(user_id)
+        model = getattr(plugin, "InputModel", None)
+        if isinstance(model, type) and issubclass(model, BaseModel):
+            try:
+                payload = model.model_validate(payload).model_dump()
+            except ValidationError as exc:
+                return {"error": exc.errors()}
         return plugin.run(state, payload)
 
     def reset(self) -> None:

--- a/src/libreassistant/plugins/echo.py
+++ b/src/libreassistant/plugins/echo.py
@@ -7,12 +7,22 @@ from __future__ import annotations
 
 from typing import Any, Dict
 
+from pydantic import BaseModel
+
 from ..kernel import kernel
 from ..mcp_adapter import MCPPluginAdapter
 
 
+class EchoInput(BaseModel):
+    """Schema for messages handled by :class:`EchoPlugin`."""
+
+    message: str = ""
+
+
 class EchoPlugin(MCPPluginAdapter):
     """Echo back a message while updating user state via MCP server."""
+
+    InputModel = EchoInput
 
     def __init__(self) -> None:
         super().__init__("servers/echo/index.ts", "echo_message")

--- a/src/libreassistant/plugins/file_io.py
+++ b/src/libreassistant/plugins/file_io.py
@@ -6,7 +6,9 @@
 from __future__ import annotations
 
 import os
-from typing import Any, Dict, Tuple
+from typing import Any, Dict, Literal, Tuple
+
+from pydantic import BaseModel, model_validator
 
 from ..kernel import kernel
 from ..mcp_adapter import MCPPluginAdapter
@@ -34,8 +36,27 @@ def _resolver(payload: Dict[str, Any]) -> Tuple[str, Dict[str, Any]]:
     return mapping[op], params
 
 
+class FileIOInput(BaseModel):
+    """Schema for payloads accepted by :class:`FileIOPlugin`."""
+
+    operation: Literal["read", "create", "update", "delete", "list"]
+    path: str
+    content: str | None = None
+    confirm: bool | None = None
+
+    @model_validator(mode="after")
+    def _check_requirements(self) -> "FileIOInput":
+        if self.operation in {"create", "update"} and self.content is None:
+            raise ValueError("content required")
+        if self.operation in {"update", "delete"} and not self.confirm:
+            raise ValueError("confirm required")
+        return self
+
+
 class FileIOPlugin(MCPPluginAdapter):
     """Perform basic file operations through the MCP file server."""
+
+    InputModel = FileIOInput
 
     def __init__(self) -> None:
         env = {"MCP_FS_BASE_DIR": ALLOWED_BASE_DIR}

--- a/src/libreassistant/plugins/law_by_keystone.py
+++ b/src/libreassistant/plugins/law_by_keystone.py
@@ -5,13 +5,27 @@
 
 from __future__ import annotations
 
+from typing import Literal
+
+from pydantic import BaseModel
+
 from ..kernel import kernel
 from ..mcp_adapter import MCPPluginAdapter
 from . import file_io
 
 
+class LawByKeystoneInput(BaseModel):
+    """Schema for inputs to :class:`LawByKeystonePlugin`."""
+
+    query: str
+    output_path: str
+    output_format: Literal["md", "json", "html"] = "md"
+
+
 class LawByKeystonePlugin(MCPPluginAdapter):
     """Export legal research results via the MCP law server."""
+
+    InputModel = LawByKeystoneInput
 
     def __init__(self) -> None:
         env = {"MCP_FS_BASE_DIR": file_io.ALLOWED_BASE_DIR}

--- a/src/libreassistant/plugins/think_tank.py
+++ b/src/libreassistant/plugins/think_tank.py
@@ -7,12 +7,22 @@ from __future__ import annotations
 
 from typing import Any, Dict
 
+from pydantic import BaseModel
+
 from ..kernel import kernel
 from ..mcp_adapter import MCPPluginAdapter
 
 
+class ThinkTankInput(BaseModel):
+    """Payload schema for :class:`ThinkTankPlugin`."""
+
+    goal: str
+
+
 class ThinkTankPlugin(MCPPluginAdapter):
     """Orchestrate specialist agents via the MCP ThinkTank server."""
+
+    InputModel = ThinkTankInput
 
     def __init__(self) -> None:
         super().__init__("servers/think_tank/index.ts", "analyze_goal")

--- a/tests/test_file_io_plugin.py
+++ b/tests/test_file_io_plugin.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any
 
+from libreassistant.kernel import kernel
 from libreassistant.plugins import file_io
 from libreassistant.plugins.file_io import FileIOPlugin
 
@@ -121,3 +122,12 @@ def test_file_io_plugin_integration(client, tmp_path: Path) -> None:
     )
     assert response.status_code == 200
     assert response.json()["result"] == {"content": "hello"}
+
+
+def test_file_io_validation_missing_path(tmp_path: Path) -> None:
+    """Payload missing required fields should yield an error before execution."""
+
+    file_io.ALLOWED_BASE_DIR = str(tmp_path)
+    file_io.register()
+    result = kernel.invoke("file_io", "alice", {"operation": "read"})
+    assert "error" in result


### PR DESCRIPTION
## Summary
- add Pydantic input schemas for built-in plugins
- validate payloads in `kernel.invoke` before delegating to plugins
- ensure File I/O plugin rejects malformed requests

## Testing
- `pytest`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a55a17869083328c0def58d20c09f0