### PR TITLE
docs: document file io security boundaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,4 +54,10 @@ The endpoint returns empty lists when the configured directories are missing or 
 
 LibreAssistant ships with a simple `echo` plugin that returns the provided message and stores it in the user's state. It serves as a reference implementation for developing additional plugins.
 
+The `file_io` plugin offers basic filesystem access. It resolves requested
+paths to their canonical form and confines them to `ALLOWED_BASE_DIR`, which
+defaults to a `desktop` folder in the current user's home directory. This
+normalization prevents path traversal and keeps file operations within a
+designated workspace.
+
 See [docs/plugin-api.md](docs/plugin-api.md) for details on writing and registering plugins.

--- a/docs/plugin-api.md
+++ b/docs/plugin-api.md
@@ -59,3 +59,15 @@ The plugin can then be invoked through the `/api/v1/invoke` endpoint by specifyi
 ## History
 
 Each invocation is appended to a per-user log that can be retrieved via `GET /api/v1/history/{user_id}`. This history powers the Past Requests tab in the web UI and can aid debugging during plugin development.
+
+## File I/O Plugin Security
+
+The built-in `file_io` plugin exposes basic filesystem operations. It sets
+`ALLOWED_BASE_DIR` to the user's `~/desktop` directory and passes this value to
+the MCP file server through `MCP_FS_BASE_DIR`.
+
+Before any operation, the plugin normalizes user supplied paths with
+`os.path.realpath` and verifies that the result remains within
+`ALLOWED_BASE_DIR`. Requests that resolve outside this directory are rejected,
+preventing path traversal and confining access to an explicitly approved
+workspace.


### PR DESCRIPTION
## Summary
- document file_io plugin's ALLOWED_BASE_DIR and path normalization in README and plugin docs

## Testing
- `pytest` *(fails: KeyboardInterrupt after initial tests)*

------
https://chatgpt.com/codex/tasks/task_e_68a570467eb08332ae42a5e92baf092c