### PR TITLE
test: mock MCP servers and run npm deps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,15 +12,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - run: npm ci
       - uses: actions/setup-python@v4
         with:
           python-version: '3.x'
       - run: pip install '.[development]'
       - run: pytest --cov=src/libreassistant
       - run: python scripts/check_license_headers.py
-      - uses: actions/setup-node@v4
-        with:
-          node-version: '20'
-      - run: npm ci
       - run: npm test
       - run: npx --yes markdownlint-cli '**/*.md'

--- a/.markdownlintignore
+++ b/.markdownlintignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,15 +1,19 @@
 # Architecture Review
 
 ## Current Flow
-```
+
+```text
 User → Switchboard → Plugin → User State → History
 ```
+
 Plugins are Python objects registered in a microkernel. Each invocation mutates per‑user state and the API logs history entries.
 
 ## Target MCP Flow
-```
+
+```text
 User → Switchboard → MCP Client → MCP Server Tool → Audit Log
 ```
+
 The switchboard embeds an MCP client which discovers servers via registry allow‑list. Tools perform work and return JSON results while the client records audit entries. Legacy plugins remain available during migration.
 
 ### Integration Gaps

--- a/OVERVIEW.md
+++ b/OVERVIEW.md
@@ -12,8 +12,8 @@ MCP adopts a client–server model built on JSON‑RPC 2.0 transported over stdi
 
 ## Threat Model & Mitigations
 Threats include prompt injection, tool poisoning and malicious servers. Without RBAC the system mitigates risk through:
-- explicit server allow‑lists
-- consent prompts for destructive operations
-- a deny‑by‑default network policy
-- filesystem jails for file tools
-- exhaustive audit logging of JSON‑RPC frames
+* explicit server allow‑lists
+* consent prompts for destructive operations
+* a deny‑by‑default network policy
+* filesystem jails for file tools
+* exhaustive audit logging of JSON‑RPC frames

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,6 +6,7 @@
 from __future__ import annotations
 
 import pathlib
+import shutil
 import sys
 from typing import Generator
 
@@ -15,6 +16,14 @@ from fastapi.testclient import TestClient
 # Add the src directory to the Python path so the package can be imported
 # without installation.
 sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1] / "src"))
+
+if shutil.which("node") is None:
+    # Mock out MCP-based plugins when Node.js isn't available to keep tests
+    # hermetic. In particular the law_by_keystone plugin would otherwise spawn
+    # a Node server during app creation.
+    from libreassistant.plugins import law_by_keystone as _law_by_keystone  # type: ignore  # noqa: E402
+
+    _law_by_keystone.register = lambda: None  # type: ignore
 
 from libreassistant.main import app  # noqa: E402
 from libreassistant.kernel import kernel  # noqa: E402

--- a/tests/test_law_by_keystone_plugin.py
+++ b/tests/test_law_by_keystone_plugin.py
@@ -1,10 +1,34 @@
 import json
+import shutil
 from pathlib import Path
 
 from typing import Any
 
+import pytest
+
 from libreassistant.plugins import file_io, law_by_keystone
 from libreassistant.plugins.law_by_keystone import LawByKeystonePlugin
+
+
+if shutil.which("node") is None:
+    class _DummyClient:
+        def __init__(self, module, env=None, timeout=None):
+            pass
+
+        def request(self, method, params=None, timeout=None):
+            return {"tools": []}
+
+        def invoke(self, tool, params):
+            output = Path(params["output_path"]) / "summary.json"
+            output.write_text(json.dumps({"query": params["query"]}))
+            return {"status": "exported"}
+
+        def close(self):
+            pass
+
+    @pytest.fixture(autouse=True)
+    def _mock_mcp_client(monkeypatch):
+        monkeypatch.setattr("libreassistant.mcp_adapter.MCPClient", _DummyClient)
 
 
 def test_export_creates_file(tmp_path: Path) -> None:

--- a/tests/test_mcp_adapter.py
+++ b/tests/test_mcp_adapter.py
@@ -1,6 +1,52 @@
+import json
 import subprocess
+import sys
+import textwrap
+
 import pytest
+
 from libreassistant.mcp_adapter import MCPClient
+
+
+@pytest.fixture
+def mock_mcp_server():
+    """Provide a minimal stand-in MCP server implemented in Python.
+
+    This avoids requiring a Node.js environment during tests while still
+    exercising the JSON-RPC plumbing used by :class:`MCPClient`.
+    """
+
+    script = textwrap.dedent(
+        """
+        import json
+        import sys
+
+        for line in sys.stdin:
+            req = json.loads(line)
+            if req["method"] == "listTools":
+                res = {"jsonrpc": "2.0", "id": req["id"], "result": {"tools": []}}
+            else:
+                res = {
+                    "jsonrpc": "2.0",
+                    "id": req["id"],
+                    "error": {"message": "unknown method"},
+                }
+            print(json.dumps(res))
+            sys.stdout.flush()
+        """
+    )
+
+    proc = subprocess.Popen(
+        [sys.executable, "-u", "-c", script],
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        text=True,
+    )
+    try:
+        yield proc
+    finally:
+        if proc.poll() is None:
+            proc.kill()
 
 
 def test_request_times_out():
@@ -13,5 +59,16 @@ def test_request_times_out():
     try:
         with pytest.raises(TimeoutError):
             client.request("listTools", timeout=0.1)
+    finally:
+        client.close()
+
+
+def test_list_tools_mock_server(mock_mcp_server):
+    client = MCPClient.__new__(MCPClient)
+    client.proc = mock_mcp_server
+    client.next_id = 1
+    client.timeout = None
+    try:
+        assert client.request("listTools") == {"tools": []}
     finally:
         client.close()


### PR DESCRIPTION
## Summary
- install Node dependencies before Python tests in CI
- mock MCP-based law_by_keystone plugin when Node isn't available
- add a simple Python MCP server for adapter tests
- fix markdown formatting and ignore node_modules for linting

## Testing
- `npm ci`
- `npm test`
- `pytest`
- `npx --yes markdownlint-cli '**/*.md'`


------
https://chatgpt.com/codex/tasks/task_e_68a5704014a8833296e80232b654773e