### PR TITLE
feat: add MCP server consent registry

### DIFF
--- a/config/mcp.consent.json
+++ b/config/mcp.consent.json
@@ -1,0 +1,1 @@
+{"echo": true, "files": true, "law_by_keystone": true, "think_tank": true}

--- a/src/libreassistant/main.py
+++ b/src/libreassistant/main.py
@@ -53,11 +53,28 @@ def create_app() -> FastAPI:
         response.headers["Content-Security-Policy"] = csp
         return response
 
-    # Register built-in plugins
-    echo.register()
-    file_io.register()
-    law_by_keystone.register()
-    think_tank.register()
+    registry_file = Path("config/mcp.registry.json")
+    if registry_file.exists():
+        registry = json.loads(registry_file.read_text())
+    else:  # pragma: no cover - file may be missing in tests
+        registry = {"servers": []}
+
+    consent_file = Path("config/mcp.consent.json")
+    if consent_file.exists():
+        mcp_consent: Dict[str, bool] = json.loads(consent_file.read_text())
+    else:  # pragma: no cover - file may be missing in tests
+        mcp_consent = {}
+
+    # Register built-in plugins only if consent has been granted
+    plugin_modules = {
+        "echo": echo,
+        "files": file_io,
+        "law_by_keystone": law_by_keystone,
+        "think_tank": think_tank,
+    }
+    for name, mod in plugin_modules.items():
+        if mcp_consent.get(name, False):
+            mod.register()
 
     # Register default providers
     providers.register("cloud", CloudProvider())
@@ -68,15 +85,6 @@ def create_app() -> FastAPI:
     @app.on_event("shutdown")
     def _cleanup_plugins() -> None:
         kernel.shutdown()
-
-    registry_file = Path("config/mcp.registry.json")
-    if registry_file.exists():
-        registry = json.loads(registry_file.read_text())
-        mcp_plugins: List[str] = [
-            s["name"] for s in registry.get("servers", [])
-        ]
-    else:  # pragma: no cover - file may be missing in tests
-        mcp_plugins = []
 
     @app.get("/")
     def read_root() -> Dict[str, str]:
@@ -134,9 +142,26 @@ def create_app() -> FastAPI:
         )
         return {"status": "ok"}
 
-    @app.get("/api/v1/mcp/plugins")
-    def list_mcp_plugins() -> Dict[str, List[str]]:
-        return {"plugins": mcp_plugins}
+    @app.get("/api/v1/mcp/servers")
+    def list_mcp_servers() -> Dict[str, Any]:
+        servers = [
+            {"name": s["name"], "consent": mcp_consent.get(s["name"], False)}
+            for s in registry.get("servers", [])
+        ]
+        return {"servers": servers}
+
+    class ServerConsent(BaseModel):
+        consent: bool
+
+    @app.post("/api/v1/mcp/consent/{name}")
+    def set_server_consent(name: str, req: ServerConsent) -> Dict[str, str]:
+        mcp_consent[name] = req.consent
+        consent_file.write_text(json.dumps(mcp_consent))
+        return {"status": "ok"}
+
+    @app.get("/api/v1/mcp/consent/{name}")
+    def get_server_consent(name: str) -> Dict[str, bool]:
+        return {"consent": mcp_consent.get(name, False)}
 
     class VaultData(BaseModel):
         data: Dict[str, Any]

--- a/src/mcp/registry.ts
+++ b/src/mcp/registry.ts
@@ -9,8 +9,31 @@ interface RegistryConfig {
   allowedHosts?: string[];
 }
 
-export async function loadRegistry(configPath: string, client: MCPClient) {
-  const config: RegistryConfig = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
+/**
+ * Load MCP servers from a registry file while enforcing per-server consent.
+ * Only servers explicitly granted consent will be registered with the client.
+ *
+ * @param configPath Path to the registry configuration listing available servers
+ * @param client     MCP client instance used for registration
+ * @param consentPath Optional path to a JSON file mapping server names to
+ *                    boolean consent flags. Defaults to `mcp.consent.json`
+ *                    in the same directory as the config file.
+ */
+export async function loadRegistry(
+  configPath: string,
+  client: MCPClient,
+  consentPath?: string,
+) {
+  const config: RegistryConfig = JSON.parse(
+    fs.readFileSync(configPath, 'utf-8'),
+  );
+  const consentFile =
+    consentPath ||
+    path.resolve(path.dirname(configPath), 'mcp.consent.json');
+  let consent: Record<string, boolean> = {};
+  if (fs.existsSync(consentFile)) {
+    consent = JSON.parse(fs.readFileSync(consentFile, 'utf-8'));
+  }
   const runner = path.resolve(
     path.dirname(fileURLToPath(import.meta.url)),
     'server-runner.js'
@@ -19,6 +42,7 @@ export async function loadRegistry(configPath: string, client: MCPClient) {
     client.setAllowedHosts(config.allowedHosts);
   }
   for (const entry of config.servers) {
+    if (!consent[entry.name]) continue;
     const modulePath = path.resolve(entry.module);
     const transport = new StdioTransport('node', [
       '--loader',

--- a/tests/mcp/consent.test.ts
+++ b/tests/mcp/consent.test.ts
@@ -1,0 +1,19 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { MCPClient } from '../../src/mcp/client.js';
+import { loadRegistry } from '../../src/mcp/registry.js';
+import path from 'path';
+import fs from 'fs';
+
+test('registry enforces server consent', async () => {
+  const client = new MCPClient();
+  const consentPath = path.resolve('config/tmp.consent.json');
+  fs.writeFileSync(consentPath, JSON.stringify({ echo: true }));
+  try {
+    await loadRegistry(path.resolve('config/mcp.registry.json'), client, consentPath);
+    assert.deepEqual(client.listServers(), ['echo']);
+  } finally {
+    client.close();
+    fs.unlinkSync(consentPath);
+  }
+});

--- a/tests/test_mcp_consent.py
+++ b/tests/test_mcp_consent.py
@@ -1,0 +1,13 @@
+from fastapi.testclient import TestClient
+
+
+def test_mcp_consent_endpoints(client: TestClient) -> None:
+    resp = client.get('/api/v1/mcp/servers')
+    data = resp.json()
+    names = {s['name'] for s in data['servers']}
+    assert 'echo' in names
+    off = client.post('/api/v1/mcp/consent/echo', json={'consent': False})
+    assert off.status_code == 200
+    check = client.get('/api/v1/mcp/consent/echo')
+    assert check.json()['consent'] is False
+    client.post('/api/v1/mcp/consent/echo', json={'consent': True})

--- a/ui/components/plugin-catalogue.js
+++ b/ui/components/plugin-catalogue.js
@@ -59,9 +59,9 @@ class LAPluginCatalogue extends HTMLElement {
 
   async loadPlugins() {
     try {
-      const res = await fetch('/api/v1/mcp/plugins');
+      const res = await fetch('/api/v1/mcp/servers');
       const data = await res.json();
-      this.plugins = data.plugins.map(name => ({ name, enabled: false }));
+      this.plugins = data.servers || [];
     } catch {
       this.plugins = [];
     }
@@ -87,12 +87,21 @@ class LAPluginCatalogue extends HTMLElement {
     label.textContent = plugin.name;
     const toggle = document.createElement('input');
     toggle.type = 'checkbox';
-    toggle.checked = plugin.enabled;
-    toggle.addEventListener('change', () => {
-      plugin.enabled = toggle.checked;
-      this.dispatchEvent(new CustomEvent('plugin-toggle', {
-        detail: { name: plugin.name, enabled: plugin.enabled }
-      }));
+    toggle.checked = plugin.consent;
+    toggle.addEventListener('change', async () => {
+      plugin.consent = toggle.checked;
+      try {
+        await fetch(`/api/v1/mcp/consent/${plugin.name}`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ consent: plugin.consent })
+        });
+      } catch {}
+      this.dispatchEvent(
+        new CustomEvent('plugin-toggle', {
+          detail: { name: plugin.name, consent: plugin.consent }
+        })
+      );
     });
     label.prepend(toggle);
     li.appendChild(label);


### PR DESCRIPTION
## Summary
- enforce server-level consent when loading MCP registry
- expose API and UI for viewing and toggling MCP server consent
- cover registry consent logic with unit tests

## Testing
- `pytest -q`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a57034b08c8332b54d62d75c5639c5