### PR TITLE
docs: restructure readme and refresh api docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,63 +1,105 @@
 <!-- Copyright (c) 2024 LibreAssistant contributors. Licensed under the MIT License. -->
 
 # LibreAssistant
-A FOSS alternative to next-gen AI assistants like Google Gemini and ChatGPT.
 
-Continuous integration runs tests, Markdown style checks, and license header verification on every pull request.
+LibreAssistant is an open‑source AI assistant you can run locally. It pairs a
+Python microkernel with auditable plugins and a themeable web interface so you
+stay in control of every request.
 
-## Features
+This guide focuses on getting you up and running and showcasing creative ways to
+use the built‑in tools.
 
-- **Design System** – token-based CSS with Light, Dark, and High-Contrast themes plus accessible web components (primary button, input field, information card, modal dialog)
-- **Main UI** – a tabbed layout with sections for Switchboard, Catalogue, Past Requests, and User Profile plus a six‑step onboarding flow
-- **Switchboard & Providers** – request composer with twelve plugin slots, provider registry for cloud or local models, and an initial system prompt
-- **Plugin Catalogue** – searchable list with enable/disable toggles
-- **Past Requests** – history API and `<la-past-requests>` component to review plugin interactions
-- **Personal Data Vault** – encrypted, consent-aware storage with export and deletion endpoints
-- **Transparency Dashboards** – Bill of Materials and System Health endpoints with corresponding web components
-- **Theme Marketplace** – browse, preview, rate, and install community themes from a dedicated repository; styles are sanitized server-side, loaded in sandboxed iframes, and served with a strict Content Security Policy
+## Highlights
 
-## Development
+- **Chat with models you trust** – point LibreAssistant at local or cloud
+  providers and inspect every request.
+- **Do more with plugins** – read and write files, analyse goals, or integrate
+  your own tools.
+- **Transparent by design** – dashboards reveal system health and every
+  component that participates in a request.
+- **Customisable UI** – switch between light, dark, or community themes.
 
-A Docker-based environment is provided for local development. Start the API with:
+## Quick Start
+
+### Prerequisites
+
+- [Docker](https://docs.docker.com/get-docker/) and Docker Compose
+- [Python 3.10+](https://www.python.org/downloads/)
+- [Node.js 20+](https://nodejs.org/en/download) for TypeScript components
+
+### Clone and Launch
 
 ```sh
+git clone https://github.com/LibreAssistant/LibreAssistant.git
+cd LibreAssistant
 docker compose up --build
 ```
 
-The service will be available at [http://localhost:8000](http://localhost:8000).
+Visit [http://localhost:8000](http://localhost:8000) to open the switchboard
+interface.
 
-Install dependencies and run the test suite with:
+### Optional: Python Development Setup
+
+Install Python dependencies if you want to run unit tests or work on the core
+microkernel:
 
 ```sh
 python -m pip install -e .[dev]
-pytest
 ```
 
-Rebuild the theme catalog after adding or updating themes with:
+## First Steps in the UI
+
+The switchboard presents tabs for composing requests, browsing plugins, viewing
+past activity, and updating your profile. Start a conversation by entering a
+prompt in the request tab and choosing a model provider.
+
+## Example Requests
+
+### Brainstorm with the Think Tank Plugin
 
 ```sh
-python scripts/build_theme_catalog.py
+curl -X POST http://localhost:8000/api/v1/invoke \
+  -H "Content-Type: application/json" \
+  -d '{
+        "plugin": "think_tank",
+        "user_id": "alice",
+        "payload": {"goal": "Improve education"}
+      }'
 ```
 
-### Model and Dataset Directories
-
-The bill of materials endpoint inspects local directories to report installed artifacts. By default it scans `models/` and `datasets/` relative to the project root. These paths can be customized with environment variables:
+### Save a Note with the File I/O Plugin
 
 ```sh
-export LA_MODELS_DIR=/path/to/models
-export LA_DATASETS_DIR=/path/to/datasets
+curl -X POST http://localhost:8000/api/v1/invoke \
+  -H "Content-Type: application/json" \
+  -d '{
+        "plugin": "file_io",
+        "user_id": "alice",
+        "payload": {
+          "operation": "create",
+          "path": "~/desktop/note.txt",
+          "content": "hello"
+        }
+      }'
 ```
 
-The endpoint returns empty lists when the configured directories are missing or contain no entries.
+## Customise and Extend
 
-## Plugins
+- **Add providers** – set API keys at
+  `/api/v1/providers/{name}/key` to use cloud models.
+- **Pick a theme** – apply a community style from
+  `/api/v1/themes/{name}.css` or design your own.
+- **Write plugins** – see [docs/plugin-api.md](docs/plugin-api.md) for a guide
+  to building and registering new tools.
 
-LibreAssistant ships with a simple `echo` plugin that returns the provided message and stores it in the user's state. It serves as a reference implementation for developing additional plugins.
+## Architecture Overview
 
-The `file_io` plugin offers basic filesystem access. It resolves requested
-paths to their canonical form and confines them to `ALLOWED_BASE_DIR`, which
-defaults to a `desktop` folder in the current user's home directory. This
-normalization prevents path traversal and keeps file operations within a
-designated workspace.
+Under the hood, LibreAssistant uses a Python microkernel with plugins that may
+delegate to TypeScript MCP servers. History, audit logs, and transparency
+dashboards track each request so you can inspect how outputs were produced.
 
-See [docs/plugin-api.md](docs/plugin-api.md) for details on writing and registering plugins.
+## Further Reading
+
+- [docs/api.md](docs/api.md) – REST API endpoints
+- [ARCHITECTURE.md](ARCHITECTURE.md) – system flows and design goals
+- [OVERVIEW.md](OVERVIEW.md) – background on the Model Context Protocol

--- a/docs/api.md
+++ b/docs/api.md
@@ -26,6 +26,12 @@ LibreAssistant exposes a FastAPI service with endpoints for plugin invocation, u
 - `POST /api/v1/providers/{name}/key` – configure an API key for a provider
 - `POST /api/v1/generate` – generate a response using the specified provider
 
+## MCP Registry
+- `GET /api/v1/mcp/servers` – list servers from the MCP registry and their
+  consent status
+- `POST /api/v1/mcp/consent/{name}` – set consent for an MCP server
+- `GET /api/v1/mcp/consent/{name}` – get consent for an MCP server
+
 ## Themes
 - `GET /api/v1/themes/{theme_id}.css` – return sanitized CSS for a theme. The response is served with a strict `Content-Security-Policy` header.
 

--- a/docs/plugin-api.md
+++ b/docs/plugin-api.md
@@ -60,6 +60,23 @@ The plugin can then be invoked through the `/api/v1/invoke` endpoint by specifyi
 
 Each invocation is appended to a per-user log that can be retrieved via `GET /api/v1/history/{user_id}`. This history powers the Past Requests tab in the web UI and can aid debugging during plugin development.
 
+## MCP Server Integration
+
+Many plugins delegate work to external Model Context Protocol (MCP) servers.
+`MCPPluginAdapter` wraps a server tool and exposes it through the standard
+`run` interface:
+
+```python
+from libreassistant.mcp_adapter import MCPPluginAdapter
+
+class EchoPlugin(MCPPluginAdapter):
+    def __init__(self) -> None:
+        super().__init__("servers/echo/index.ts", "echo_message")
+```
+
+The adapter handles JSON‑RPC communication with the TypeScript server and
+returns the tool's JSON response to the microkernel.
+
 ## File I/O Plugin Security
 
 The built-in `file_io` plugin exposes basic filesystem operations. It sets


### PR DESCRIPTION
## Summary
- rewrite README with end-user quick start, examples, and customization guides
- document MCP registry endpoints and MCPPluginAdapter usage

## Testing
- `python -m pip install -e .[dev]` *(fails: No matching distribution found for types-cssutils)*
- `python -m pip install types-cssutils` *(fails: No matching distribution found for types-cssutils)*
- `npx markdownlint-cli '**/*.md'`
- `python scripts/check_license_headers.py` *(fails: missing MIT license header in many files)*
- `python -m pip install httpx`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a595d46e688332a85cca7c43f3f7fc