### PR TITLE
refactor: rename loop variable in audit log

### DIFF
--- a/src/libreassistant/main.py
+++ b/src/libreassistant/main.py
@@ -3,7 +3,7 @@
 
 """Application entrypoints and FastAPI app factory."""
 
-from typing import Any, Dict, List
+from typing import Any, Dict
 
 from fastapi import FastAPI, HTTPException, Request
 from fastapi.responses import Response
@@ -130,9 +130,9 @@ def create_app() -> FastAPI:
         if not log_path.exists():
             return {"logs": []}
         lines = [
-            json.loads(l)
-            for l in log_path.read_text().splitlines()
-            if l.strip()
+            json.loads(line)
+            for line in log_path.read_text().splitlines()
+            if line.strip()
         ]
         return {"logs": lines}
 
@@ -142,9 +142,9 @@ def create_app() -> FastAPI:
         if not log_path.exists():
             return {"logs": []}
         lines = [
-            json.loads(l)
-            for l in log_path.read_text().splitlines()
-            if l.strip()
+            json.loads(line)
+            for line in log_path.read_text().splitlines()
+            if line.strip()
         ]
         filtered = [e for e in lines if e.get("user_id") == user_id]
         return {"logs": filtered}


### PR DESCRIPTION
## Summary
- remove unused `List` import in `main.py`
- rename audit log loop variable `l` to `line`

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a5e99733bc8332a5e01e7bffcfd1a5