### PR TITLE
Encrypt provider API keys with Fernet

### DIFF
--- a/src/libreassistant/providers/__init__.py
+++ b/src/libreassistant/providers/__init__.py
@@ -7,6 +7,8 @@ from __future__ import annotations
 
 from typing import Dict, Protocol
 
+from cryptography.fernet import Fernet
+
 
 class Provider(Protocol):
     """Protocol defining an AI provider."""
@@ -20,22 +22,25 @@ class ProviderManager:
 
     def __init__(self) -> None:
         self._providers: Dict[str, Provider] = {}
-        self._api_keys: Dict[str, str] = {}
+        self._api_keys: Dict[str, bytes] = {}
+        self._fernet = Fernet(Fernet.generate_key())
 
     def register(self, name: str, provider: Provider) -> None:
         """Register a provider implementation."""
         self._providers[name] = provider
 
     def set_api_key(self, name: str, key: str) -> None:
-        """Store the API key for a provider."""
-        self._api_keys[name] = key
+        """Store the API key for a provider encrypted with Fernet."""
+        token = self._fernet.encrypt(key.encode())
+        self._api_keys[name] = token
 
     def generate(self, name: str, prompt: str) -> str:
         """Generate a response using the named provider."""
         provider = self._providers.get(name)
         if provider is None:
             raise KeyError(name)
-        key = self._api_keys.get(name)
+        token = self._api_keys.get(name)
+        key = self._fernet.decrypt(token).decode() if token else None
         return provider.generate(prompt, key)
 
     def reset(self) -> None:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -19,11 +19,13 @@ sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1] / "src"))
 
 if shutil.which("node") is None:
     # Mock out MCP-based plugins when Node.js isn't available to keep tests
-    # hermetic. In particular the law_by_keystone plugin would otherwise spawn
-    # a Node server during app creation.
+    # hermetic. These plugins would otherwise spawn a Node server during app
+    # creation.
     from libreassistant.plugins import law_by_keystone as _law_by_keystone  # type: ignore  # noqa: E402
+    from libreassistant.plugins import think_tank as _think_tank  # type: ignore  # noqa: E402
 
     _law_by_keystone.register = lambda: None  # type: ignore
+    _think_tank.register = lambda: None  # type: ignore
 
 from libreassistant.main import app  # noqa: E402
 from libreassistant.kernel import kernel  # noqa: E402

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -5,6 +5,8 @@
 
 from __future__ import annotations
 
+from libreassistant.providers import providers
+
 
 def test_local_provider(client) -> None:
     response = client.post(
@@ -23,8 +25,33 @@ def test_cloud_provider_requires_key(client) -> None:
     assert bad.status_code == 400
     set_key = client.post("/api/v1/providers/cloud/key", json={"key": "abc"})
     assert set_key.status_code == 200
+    token = providers._api_keys["cloud"]
+    assert isinstance(token, bytes)
+    assert token != b"abc"
     good = client.post(
         "/api/v1/generate",
         json={"provider": "cloud", "prompt": "hi"},
     )
     assert good.json() == {"result": "cloud:hi"}
+
+
+def test_api_key_encrypted_storage() -> None:
+    class CaptureProvider:
+        def __init__(self) -> None:
+            self.received: str | None = None
+
+        def generate(self, prompt: str, api_key: str | None = None) -> str:
+            self.received = api_key
+            return "ok"
+
+    provider = CaptureProvider()
+    providers.register("capture", provider)
+    providers.set_api_key("capture", "secret")
+
+    token = providers._api_keys["capture"]
+    assert isinstance(token, bytes)
+    assert token != b"secret"
+    assert providers._fernet.decrypt(token).decode() == "secret"
+
+    providers.generate("capture", "hi")
+    assert provider.received == "secret"


### PR DESCRIPTION
## Summary
- Encrypt stored provider API keys using `cryptography.Fernet`
- Decrypt keys before invoking provider `generate`
- Add tests verifying encrypted key storage and decrypted use
- Mock Node-based plugins when Node.js is unavailable for tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a5e9cefa50833281043d309c899b03