### PR TITLE
Use threaded MCP client read loop

### DIFF
--- a/src/libreassistant/mcp_adapter.py
+++ b/src/libreassistant/mcp_adapter.py
@@ -4,8 +4,9 @@ from __future__ import annotations
 import json
 import logging
 import os
-import select
+import queue
 import subprocess
+import threading
 from pathlib import Path
 from typing import Any, Callable, Dict, Tuple
 
@@ -45,6 +46,17 @@ class MCPClient:
         self.next_id = 1
         self.timeout = timeout
 
+        self._queue: queue.Queue[str | None] = queue.Queue()
+
+        def _reader() -> None:
+            assert self.proc.stdout
+            for line in self.proc.stdout:
+                self._queue.put(line)
+            self._queue.put(None)
+
+        self._reader = threading.Thread(target=_reader, daemon=True)
+        self._reader.start()
+
         # Perform a basic handshake to ensure the server is ready
         self.request("listTools")
 
@@ -58,18 +70,21 @@ class MCPClient:
         self.next_id += 1
         if params is not None:
             req["params"] = params
-        assert self.proc.stdin and self.proc.stdout
+        assert self.proc.stdin
         self.proc.stdin.write(json.dumps(req) + "\n")
         self.proc.stdin.flush()
         wait = self.timeout if timeout is None else timeout
-        if wait is not None:
-            ready, _, _ = select.select([self.proc.stdout], [], [], wait)
-            if not ready:
-                raise TimeoutError(
-                    f"MCP server did not respond within {wait} seconds"
-                )
-        line = self.proc.stdout.readline()
-        if not line:
+        try:
+            line = (
+                self._queue.get(timeout=wait)
+                if wait is not None
+                else self._queue.get()
+            )
+        except queue.Empty:
+            raise TimeoutError(
+                f"MCP server did not respond within {wait} seconds"
+            ) from None
+        if line is None:
             raise RuntimeError("no response from MCP server")
         res = json.loads(line)
         if "error" in res:
@@ -85,6 +100,9 @@ class MCPClient:
             self.proc.wait()
         except Exception as exc:  # pragma: no cover - best effort
             logging.debug("Exception while terminating MCPClient process: %s", exc)
+        finally:
+            if getattr(self, "_reader", None) and self._reader.is_alive():
+                self._reader.join(timeout=0.1)
 
 
 Resolver = Callable[[Dict[str, Any]], Tuple[str, Dict[str, Any]]]
@@ -129,3 +147,4 @@ class MCPPluginAdapter:
             return self.client.invoke(tool, params)
         except Exception as exc:
             return {"error": str(exc)}
+

--- a/tests/test_mcp_adapter.py
+++ b/tests/test_mcp_adapter.py
@@ -1,6 +1,8 @@
 import subprocess
 import sys
 import textwrap
+import queue
+import threading
 
 import pytest
 
@@ -45,6 +47,19 @@ def mock_mcp_server():
             proc.kill()
 
 
+def _setup_client(client: MCPClient) -> None:
+    client._queue = queue.Queue()
+
+    def _reader() -> None:
+        assert client.proc.stdout
+        for line in client.proc.stdout:
+            client._queue.put(line)
+        client._queue.put(None)
+
+    client._reader = threading.Thread(target=_reader, daemon=True)
+    client._reader.start()
+
+
 def test_request_times_out():
     client = MCPClient.__new__(MCPClient)
     client.proc = subprocess.Popen(
@@ -52,6 +67,7 @@ def test_request_times_out():
     )
     client.next_id = 1
     client.timeout = None
+    _setup_client(client)
     try:
         with pytest.raises(TimeoutError):
             client.request("listTools", timeout=0.1)
@@ -64,6 +80,7 @@ def test_list_tools_mock_server(mock_mcp_server):
     client.proc = mock_mcp_server
     client.next_id = 1
     client.timeout = None
+    _setup_client(client)
     try:
         assert client.request("listTools") == {"tools": []}
     finally:


### PR DESCRIPTION
## Summary
- replace `select.select` with a background thread feeding a queue for portable timeouts
- ensure MCP client shutdown joins reader thread
- adjust adapter tests to use the new queue-based reader

## Testing
- `pytest tests/test_mcp_adapter.py::test_request_times_out -q`
- `pytest tests/test_mcp_adapter.py::test_list_tools_mock_server -q`
- `pytest tests/test_law_by_keystone_plugin.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a5f4a28784833293c0f2053a31888b