### PR TITLE
Handle missing MCP pipes

### DIFF
--- a/src/libreassistant/mcp_adapter.py
+++ b/src/libreassistant/mcp_adapter.py
@@ -49,7 +49,8 @@ class MCPClient:
         self._queue: queue.Queue[str | None] = queue.Queue()
 
         def _reader() -> None:
-            assert self.proc.stdout
+            if self.proc.stdout is None:
+                raise RuntimeError("MCPClient process has no stdout")
             for line in self.proc.stdout:
                 self._queue.put(line)
             self._queue.put(None)
@@ -70,7 +71,8 @@ class MCPClient:
         self.next_id += 1
         if params is not None:
             req["params"] = params
-        assert self.proc.stdin
+        if self.proc.stdin is None:
+            raise RuntimeError("MCPClient process has no stdin")
         self.proc.stdin.write(json.dumps(req) + "\n")
         self.proc.stdin.flush()
         wait = self.timeout if timeout is None else timeout

--- a/tests/test_mcp_adapter.py
+++ b/tests/test_mcp_adapter.py
@@ -51,7 +51,8 @@ def _setup_client(client: MCPClient) -> None:
     client._queue = queue.Queue()
 
     def _reader() -> None:
-        assert client.proc.stdout
+        if client.proc.stdout is None:
+            raise RuntimeError("MCPClient process has no stdout")
         for line in client.proc.stdout:
             client._queue.put(line)
         client._queue.put(None)
@@ -83,5 +84,42 @@ def test_list_tools_mock_server(mock_mcp_server):
     _setup_client(client)
     try:
         assert client.request("listTools") == {"tools": []}
+    finally:
+        client.close()
+
+
+def test_request_no_stdin():
+    client = MCPClient.__new__(MCPClient)
+    client.proc = subprocess.Popen(
+        ["sleep", "100"], stdin=subprocess.PIPE, stdout=subprocess.PIPE, text=True
+    )
+    client.proc.stdin.close()
+    client.proc.stdin = None
+    client.next_id = 1
+    client.timeout = None
+    try:
+        with pytest.raises(RuntimeError, match="no stdin"):
+            client.request("listTools")
+    finally:
+        client.close()
+
+
+def test_reader_no_stdout():
+    client = MCPClient.__new__(MCPClient)
+    client.proc = subprocess.Popen(
+        ["sleep", "100"], stdin=subprocess.PIPE, stdout=None, text=True
+    )
+    client._queue = queue.Queue()
+
+    def _reader() -> None:
+        if client.proc.stdout is None:
+            raise RuntimeError("MCPClient process has no stdout")
+        for line in client.proc.stdout:
+            client._queue.put(line)
+        client._queue.put(None)
+
+    try:
+        with pytest.raises(RuntimeError, match="no stdout"):
+            _reader()
     finally:
         client.close()


### PR DESCRIPTION
## Summary
- raise `RuntimeError` when MCP subprocess lacks `stdin`/`stdout` instead of relying on `assert`
- add regression tests for missing pipes

## Testing
- `pytest tests/test_mcp_adapter.py`

------
https://chatgpt.com/codex/tasks/task_e_68a5fac0b53c8332a13b4a6b2573d2f4