### PR TITLE
Use bounded deque for error tracking

### DIFF
--- a/src/libreassistant/transparency.py
+++ b/src/libreassistant/transparency.py
@@ -7,8 +7,9 @@ from __future__ import annotations
 
 import os
 import time
+from collections import deque
 from pathlib import Path
-from typing import Any, Dict, List
+from typing import Any, Deque, Dict, List
 
 import importlib.metadata
 
@@ -20,7 +21,7 @@ class HealthMonitor:
         self.start_time = time.time()
         self.requests = 0
         self.error_count = 0
-        self.errors: List[str] = []
+        self.errors: Deque[str] = deque(maxlen=100)
 
     def record_request(self) -> None:
         """Increment the total request count."""
@@ -39,7 +40,7 @@ class HealthMonitor:
             "uptime": time.time() - self.start_time,
             "requests": self.requests,
             "error_count": self.error_count,
-            "errors": self.errors,
+            "errors": list(self.errors),
         }
 
 

--- a/tests/test_transparency.py
+++ b/tests/test_transparency.py
@@ -82,3 +82,15 @@ def test_error_tracking(client):
     after_status = client.get("/api/v1/health").json()
     assert after_status["error_count"] == before_status["error_count"] + 1
     assert after_status["status"] == "error"
+
+
+def test_health_monitor_discards_old_errors():
+    from libreassistant.transparency import HealthMonitor
+
+    monitor = HealthMonitor()
+    for i in range(105):
+        monitor.record_error(f"err-{i}")
+    status = monitor.get_status()
+    assert status["error_count"] == 105
+    assert len(status["errors"]) == 100
+    assert status["errors"][0] == "err-5"


### PR DESCRIPTION
## Summary
- Switch `HealthMonitor` to a `deque` capped at 100 entries for storing errors
- Ensure status endpoint serializes error deque to list
- Add regression test verifying old errors drop off once limit reached

## Testing
- `pytest tests/test_transparency.py`


------
https://chatgpt.com/codex/tasks/task_e_68a5fac93ddc83329e91fbceccee35d9