### PR TITLE
feat: add law API integration and audit source tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,27 @@ curl -X POST http://localhost:8000/api/v1/invoke \
       }'
 ```
 
+### Search Government Data with the Law Plugin
+
+```sh
+curl -X POST http://localhost:8000/api/v1/invoke \
+  -H "Content-Type: application/json" \
+  -d '{
+        "plugin": "law_by_keystone",
+        "user_id": "alice",
+        "payload": {
+          "query": "education",
+          "source": "govtrack",
+          "output_format": "json",
+          "output_path": "law"
+        }
+      }'
+```
+
+The law plugin connects to GovInfo, eCFR, CourtListener, Open States, and
+GovTrack APIs and can export results in Markdown, HTML, JSON, plain text, or
+XML with metadata about the query.
+
 ## Customise and Extend
 
 - **Add providers** – set API keys at

--- a/config/mcp.registry.json
+++ b/config/mcp.registry.json
@@ -5,5 +5,12 @@
     { "name": "law_by_keystone", "module": "./servers/law_by_keystone/index.ts" },
     { "name": "think_tank", "module": "./servers/think_tank/index.ts" }
   ],
-  "allowedHosts": ["localhost"]
+  "allowedHosts": [
+    "localhost",
+    "api.govinfo.gov",
+    "api.ecfr.gov",
+    "www.courtlistener.com",
+    "v3.openstates.org",
+    "www.govtrack.us"
+  ]
 }

--- a/docs/law_api.md
+++ b/docs/law_api.md
@@ -1,0 +1,41 @@
+# Law Plugin
+
+The `law_by_keystone` MCP server queries public government APIs to gather legal
+and legislative information. Supported data sources include:
+
+- **GovInfo** – federal publications
+- **eCFR** – Electronic Code of Federal Regulations
+- **CourtListener** – court opinions and dockets
+- **Open States** – state legislative data
+- **GovTrack** – congressional information
+
+## Tool
+
+`generate_legal_summary`
+
+| Parameter       | Description                                                     |
+| --------------- | --------------------------------------------------------------- |
+| `query`         | Search term or citation                                         |
+| `source`        | One of `govinfo`, `ecfr`, `courtlistener`, `openstates`, `govtrack` |
+| `output_format` | `md`, `json`, `html`, `txt`, or `xml`                            |
+| `output_path`   | Directory to write the result file                              |
+
+The tool writes a file in the requested format and returns metadata including the
+number of results and the data source used. Audit logs record the `dataSources`
+array so requests can be traced back to their origins.
+
+## Example
+
+```json
+{
+  "plugin": "law_by_keystone",
+  "user_id": "alice",
+  "payload": {
+    "query": "education",
+    "source": "govinfo",
+    "output_format": "md",
+    "output_path": "law"
+  }
+}
+```
+

--- a/logs/README.md
+++ b/logs/README.md
@@ -1,5 +1,7 @@
 # Audit logs
 
 This directory stores runtime audit logs in newline-delimited JSON (NDJSON) format.
-Each line represents an `AuditEntry` emitted by the MCP client. Logs rotate when
-the file exceeds 5 MB, renaming the current file to `audit.ndjson.1`.
+Each line represents an `AuditEntry` emitted by the MCP client. Entries now
+include a `dataSources` array noting the external APIs used during a request.
+Logs rotate when the file exceeds 5 MB, renaming the current file to
+`audit.ndjson.1`.

--- a/servers/law_by_keystone/index.ts
+++ b/servers/law_by_keystone/index.ts
@@ -1,39 +1,67 @@
 import { promises as fs } from 'fs';
 import path from 'path';
-import { MCPServer, ToolSchema, ResourceSchema, PromptSchema } from '../../src/mcp/types.js';
+import {
+  MCPServer,
+  ToolSchema,
+  ResourceSchema,
+  PromptSchema,
+} from '../../src/mcp/types.js';
 import { serveStdio } from '../../src/mcp/transport.js';
 import { fileURLToPath } from 'url';
 
 const baseDir = path.resolve(process.env.MCP_FS_BASE_DIR || './mcp_fs');
 await fs.mkdir(baseDir, { recursive: true });
 
+const SOURCES = [
+  'govinfo',
+  'ecfr',
+  'courtlistener',
+  'openstates',
+  'govtrack',
+] as const;
+
+type Source = (typeof SOURCES)[number];
+
 const tools: ToolSchema[] = [
   {
     name: 'generate_legal_summary',
-    description: 'Generate a stub legal research summary and export it',
+    description:
+      'Fetch legal information from government APIs and export it',
     parameters: {
       type: 'object',
       properties: {
         query: { type: 'string' },
-        output_format: { enum: ['md', 'json', 'html'], default: 'md' },
-        output_path: { type: 'string' }
+        source: { enum: SOURCES, default: 'govinfo' },
+        output_format: {
+          enum: ['md', 'json', 'html', 'txt', 'xml'],
+          default: 'md',
+        },
+        output_path: { type: 'string' },
       },
-      required: ['query', 'output_path']
+      required: ['query', 'output_path'],
     },
     returns: {
       type: 'object',
-      properties: { status: { enum: ['exported'] }, path: { type: 'string' } },
-      required: ['status', 'path']
-    }
-  }
+      properties: {
+        status: { enum: ['exported'] },
+        path: { type: 'string' },
+        sources: { type: 'array', items: { type: 'string' } },
+        metadata: { type: 'object' },
+      },
+      required: ['status', 'path', 'sources', 'metadata'],
+    },
+  },
 ];
 
 const resources: ResourceSchema[] = [
-  { uri: 'law:last_summary', description: 'Last legal summary generated' }
+  { uri: 'law:last_summary', description: 'Last legal summary generated' },
 ];
 
 const prompts: PromptSchema[] = [
-  { name: 'legal_research_template', template: 'Research the following query: {{query}}' }
+  {
+    name: 'legal_research_template',
+    template: 'Research the following query: {{query}}',
+  },
 ];
 
 function ensureDir(p: string) {
@@ -42,37 +70,123 @@ function ensureDir(p: string) {
   return full;
 }
 
-async function invoke(tool: string, params: any) {
-  if (tool !== 'generate_legal_summary') throw new Error(`Unknown tool ${tool}`);
-  const { query, output_format = 'md', output_path } = params;
-  const summary = {
-    query,
-    results: [{ title: 'Example Case', summary: 'No real data fetched' }]
-  };
-  let content: string;
-  let ext: string;
-  if (output_format === 'md') {
-    content = `# Research Summary\n\nQuery: ${query}\n`;
-    ext = 'md';
-  } else if (output_format === 'json') {
-    content = JSON.stringify(summary, null, 2);
-    ext = 'json';
-  } else {
-    content = `<html><body><h1>Research Summary</h1><p>Query: ${query}</p></body></html>`;
-    ext = 'html';
+function escapeXml(str: string) {
+  return str.replace(/[<>&]/g, (c) => ({ '<': '&lt;', '>': '&gt;', '&': '&amp;' }[c]!));
+}
+
+function escapeHtml(str: string) {
+  return str.replace(/[&<>]/g, (c) => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;' }[c]!));
+}
+
+async function fetchApi(source: Source, query: string) {
+  const govinfoKey = process.env.GOVINFO_API_KEY || 'DEMO_KEY';
+  const openStatesKey = process.env.OPENSTATES_API_KEY || 'DEMO_KEY';
+  const encoded = encodeURIComponent(query);
+  try {
+    switch (source) {
+      case 'govinfo':
+        return await fetch(
+          `https://api.govinfo.gov/search?q=${encoded}&pageSize=5&api_key=${govinfoKey}`,
+        ).then((r) => r.json());
+      case 'ecfr':
+        return await fetch(
+          `https://api.ecfr.gov/v1/search?query=${encoded}`,
+        ).then((r) => r.json());
+      case 'courtlistener':
+        return await fetch(
+          `https://www.courtlistener.com/api/rest/v3/search/?q=${encoded}`,
+        ).then((r) => r.json());
+      case 'openstates':
+        return await fetch(
+          `https://v3.openstates.org/bills?search=${encoded}`,
+          { headers: { 'X-API-KEY': openStatesKey } },
+        ).then((r) => r.json());
+      case 'govtrack':
+        return await fetch(
+          `https://www.govtrack.us/api/v2/bill?query=${encoded}`,
+        ).then((r) => r.json());
+    }
+  } catch (err: any) {
+    return { error: err.message };
   }
+}
+
+function formatContent(
+  data: any,
+  format: string,
+  meta: { query: string; source: string },
+) {
+  const json = { query: meta.query, source: meta.source, data };
+  switch (format) {
+    case 'json':
+      return { content: JSON.stringify(json, null, 2), ext: 'json' };
+    case 'html':
+      return {
+        content: `<html><body><pre>${escapeHtml(
+          JSON.stringify(json, null, 2),
+        )}</pre></body></html>`,
+        ext: 'html',
+      };
+    case 'txt':
+      return {
+        content: `Source: ${meta.source}\nQuery: ${meta.query}\n${JSON.stringify(
+          data,
+          null,
+          2,
+        )}`,
+        ext: 'txt',
+      };
+    case 'xml':
+      return {
+        content: `<results><source>${meta.source}</source><query>${escapeXml(
+          meta.query,
+        )}</query><data>${escapeXml(JSON.stringify(data))}</data></results>`,
+        ext: 'xml',
+      };
+    default:
+      return {
+        content:
+          `# ${meta.source} results\n\n` +
+          `Query: ${meta.query}\n\n` +
+          '```json\n' +
+          JSON.stringify(data, null, 2) +
+          '\n```\n',
+        ext: 'md',
+      };
+  }
+}
+
+async function invoke(tool: string, params: any) {
+  if (tool !== 'generate_legal_summary')
+    throw new Error(`Unknown tool ${tool}`);
+  const { query, source = 'govinfo', output_format = 'md', output_path } =
+    params;
+  const data = await fetchApi(source as Source, query);
+  const metadata = {
+    query,
+    source,
+    format: output_format,
+    resultCount:
+      Array.isArray((data as any)?.results)
+        ? (data as any).results.length
+        : (data as any)?.count,
+  };
+  const { content, ext } = formatContent(data, output_format, {
+    query,
+    source,
+  });
   const dir = ensureDir(output_path);
   await fs.mkdir(dir, { recursive: true });
   const filePath = path.join(dir, `summary.${ext}`);
   await fs.writeFile(filePath, content);
-  return { status: 'exported', path: filePath };
+  return { status: 'exported', path: filePath, sources: [source], metadata };
 }
 
 const server: MCPServer = {
   listTools: () => tools,
   listResources: () => resources,
   listPrompts: () => prompts,
-  invoke
+  invoke,
 };
 
 export default server;
@@ -80,3 +194,4 @@ export default server;
 if (process.argv[1] === fileURLToPath(import.meta.url)) {
   serveStdio(server);
 }
+

--- a/src/mcp/client.ts
+++ b/src/mcp/client.ts
@@ -100,6 +100,11 @@ export class MCPClient {
       }
     }
 
+    const sources = Array.isArray(result?.sources)
+      ? result.sources
+      : Array.isArray(result?.metadata?.sources)
+      ? result.metadata.sources
+      : undefined;
     const entry: AuditEntry = {
       server: serverName,
       tool,
@@ -108,6 +113,7 @@ export class MCPClient {
       timestamp: Date.now(),
       beforeHash,
       afterHash,
+      dataSources: sources,
     };
     this.auditLog.push(entry);
     await this.appendAudit(entry);

--- a/src/mcp/types.ts
+++ b/src/mcp/types.ts
@@ -31,4 +31,5 @@ export interface AuditEntry {
   timestamp: number;
   beforeHash?: string;
   afterHash?: string;
+  dataSources?: string[];
 }

--- a/tests/mcp/audit.test.ts
+++ b/tests/mcp/audit.test.ts
@@ -29,3 +29,18 @@ test('audit log records invocations', async () => {
     client.close();
   }
 });
+
+test('audit entry captures data sources', async () => {
+  const client = await setup();
+  try {
+    await client.invoke('law_by_keystone', 'generate_legal_summary', {
+      query: 'test',
+      source: 'govtrack',
+      output_path: 'law_audit',
+    });
+    const last = client.auditLog.at(-1);
+    assert.ok(last?.dataSources?.includes('govtrack'));
+  } finally {
+    client.close();
+  }
+});

--- a/tests/mcp/law.test.ts
+++ b/tests/mcp/law.test.ts
@@ -14,8 +14,17 @@ async function setup() {
 test('law summary generation', async () => {
   const client = await setup();
   try {
-    const res = await client.invoke('law_by_keystone', 'generate_legal_summary', { query: 'test', output_format: 'md', output_path: 'law' });
+    const res = await client.invoke('law_by_keystone', 'generate_legal_summary', {
+      query: 'test',
+      source: 'govinfo',
+      output_format: 'txt',
+      output_path: 'law',
+    });
     assert.equal(res.status, 'exported');
+    assert.ok(Array.isArray(res.sources));
+    assert.ok(res.sources.includes('govinfo'));
+    assert.equal(res.metadata.source, 'govinfo');
+    assert.equal(res.metadata.format, 'txt');
     assert.ok(fs.existsSync(res.path));
   } finally {
     client.close();


### PR DESCRIPTION
## Summary
- connect law plugin to GovInfo, eCFR, CourtListener, Open States, and GovTrack APIs
- support md, json, html, txt, and xml outputs with metadata
- log external data sources in audit records

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a60b73c0bc8332a13500cfa386e13e