### PR TITLE
Use model-driven analysis in ThinkTank experts

### DIFF
--- a/servers/think_tank/index.ts
+++ b/servers/think_tank/index.ts
@@ -2,6 +2,29 @@ import { MCPServer, ToolSchema, ResourceSchema, PromptSchema } from '../../src/m
 import { serveStdio } from '../../src/mcp/transport.js';
 import { fileURLToPath } from 'url';
 
+// -----------------------------------------------------------------------------
+// Helper that interacts with a language model.  During unit tests the
+// environment variable ``THINK_TANK_MODEL_RESPONSE`` provides a canned JSON
+// response allowing the logic to run without external network calls.  When the
+// variable is unset we attempt to use the OpenAI client.  The call is lazily
+// imported so the dependency is optional.
+
+async function callModel(prompt: string): Promise<any> {
+  const mock = process.env.THINK_TANK_MODEL_RESPONSE;
+  if (mock) {
+    return JSON.parse(mock);
+  }
+
+  const mod: any = await (eval('import'))('openai');
+  const client = new mod.OpenAI({ apiKey: process.env.OPENAI_API_KEY });
+  const completion = await client.chat.completions.create({
+    model: process.env.OPENAI_MODEL || 'gpt-3.5-turbo',
+    messages: [{ role: 'user', content: prompt }],
+  });
+  const text = completion.choices[0].message?.content || '{}';
+  return JSON.parse(text);
+}
+
 let lastDossier: any = null;
 
 const tools: ToolSchema[] = [
@@ -21,12 +44,59 @@ const tools: ToolSchema[] = [
           type: 'object',
           properties: {
             goal: { type: 'string' },
-            executive: { type: 'string' },
-            research: { type: 'string' },
-            devils_advocate: { type: 'string' },
-            argument: { type: 'string' },
-            communications: { type: 'string' },
-            visualizer: { type: 'string' }
+            executive: {
+              type: 'object',
+              properties: {
+                tasks: { type: 'array', items: { type: 'string' } }
+              },
+              required: ['tasks']
+            },
+            research: {
+              type: 'object',
+              properties: {
+                summary: { type: 'string' },
+                sources: { type: 'array', items: { type: 'string' } }
+              },
+              required: ['summary', 'sources']
+            },
+            devils_advocate: {
+              type: 'object',
+              properties: {
+                concerns: { type: 'array', items: { type: 'string' } }
+              },
+              required: ['concerns']
+            },
+            argument: {
+              type: 'object',
+              properties: {
+                points: { type: 'array', items: { type: 'string' } }
+              },
+              required: ['points']
+            },
+            communications: {
+              type: 'object',
+              properties: {
+                message: { type: 'string' },
+                audience: { type: 'string' }
+              },
+              required: ['message', 'audience']
+            },
+            visualizer: {
+              type: 'object',
+              properties: {
+                description: { type: 'string' },
+                data: {
+                  type: 'object',
+                  properties: {
+                    type: { type: 'string' },
+                    labels: { type: 'array', items: { type: 'string' } },
+                    values: { type: 'array', items: { type: 'number' } }
+                  },
+                  required: ['type', 'labels', 'values']
+                }
+              },
+              required: ['description', 'data']
+            }
           },
           required: [
             'goal',
@@ -55,22 +125,23 @@ const prompts: PromptSchema[] = [
 async function invoke(tool: string, params: any) {
   if (tool !== 'analyze_goal') throw new Error(`Unknown tool ${tool}`);
   const goal = params.goal;
-  const analysis = {
-    goal,
-    executive: `Breakdown of '${goal}' into manageable tasks.`,
-    research: `Research findings for '${goal}' (stub).`,
-    devils_advocate: `Potential issues with pursuing '${goal}'.`,
-    argument: `Supporting arguments for '${goal}'.`,
-    communications: `Clear and concise explanation of '${goal}'.`,
-    visualizer: 'Visualization not implemented in stub.'
-  };
-  const summary = [
-    analysis.communications,
-    `Argument: ${analysis.argument}`,
-    `Caveats: ${analysis.devils_advocate}`
-  ].join('\n');
-  lastDossier = { summary, analysis };
-  return lastDossier;
+  const prompt = `You are a multidisciplinary think tank. Provide a JSON object with the following structure:
+{
+  "summary": string,
+  "analysis": {
+    "goal": string,
+    "executive": {"tasks": string[]},
+    "research": {"summary": string, "sources": string[]},
+    "devils_advocate": {"concerns": string[]},
+    "argument": {"points": string[]},
+    "communications": {"message": string, "audience": string},
+    "visualizer": {"description": string, "data": {"type": string, "labels": string[], "values": number[]}}
+  }
+}
+Analyze the goal: ${goal}`;
+  const result = await callModel(prompt);
+  lastDossier = result;
+  return result;
 }
 
 const server: MCPServer = {

--- a/src/libreassistant/experts/aggregation.py
+++ b/src/libreassistant/experts/aggregation.py
@@ -1,12 +1,18 @@
-"""Aggregate expert analyses into a final summary."""
-from typing import Dict
+"""Aggregate expert analyses into a final summary via a language model."""
+
+from __future__ import annotations
+
+import json
+from typing import Any, Dict
+
+from ..providers import providers
 
 
-def summarize(analysis: Dict[str, str]) -> str:
-    """Combine expert outputs into a concise summary."""
-    parts = [
-        analysis["communications"],
-        f"Argument: {analysis['argument']}",
-        f"Caveats: {analysis['devils_advocate']}",
-    ]
-    return "\n".join(parts)
+def summarize(analysis: Dict[str, Any]) -> str:
+    """Combine expert outputs into a concise, human-readable summary."""
+
+    prompt = (
+        "Summarize the following analysis in a few sentences highlighting "
+        "communications, arguments and caveats. Return plain text.\n" + json.dumps(analysis)
+    )
+    return providers.generate("cloud", prompt)

--- a/src/libreassistant/experts/argumentation.py
+++ b/src/libreassistant/experts/argumentation.py
@@ -1,6 +1,25 @@
-"""Argumentation analysis module."""
+"""Argumentation analysis module driven by a language model."""
+
+from __future__ import annotations
+
+import json
+from typing import Dict, List
+
+from ..providers import providers
 
 
-def analyze(goal: str) -> str:
-    """Provide supporting arguments for the goal."""
-    return f"Supporting arguments for '{goal}'."
+def analyze(goal: str) -> Dict[str, List[str]]:
+    """Return a list of supporting arguments for ``goal`` using a model call."""
+
+    prompt = (
+        "Provide three persuasive arguments supporting the goal '" + goal + "'. "
+        "Respond in JSON with a 'points' array of strings."
+    )
+    raw = providers.generate("cloud", prompt)
+    try:
+        data = json.loads(raw)
+    except Exception as exc:  # pragma: no cover - invalid model output
+        raise ValueError("Model did not return valid JSON") from exc
+    if "points" not in data or not isinstance(data["points"], list):
+        raise ValueError("Model response missing 'points'")
+    return data  # type: ignore[return-value]

--- a/src/libreassistant/experts/communications.py
+++ b/src/libreassistant/experts/communications.py
@@ -1,6 +1,26 @@
-"""Communications analysis module."""
+"""Communications analysis module using a language model."""
+
+from __future__ import annotations
+
+import json
+from typing import Dict
+
+from ..providers import providers
 
 
-def analyze(goal: str) -> str:
-    """Return a clear explanation of the goal."""
-    return f"Clear and concise explanation of '{goal}'."
+def analyze(goal: str) -> Dict[str, str]:
+    """Return a structured communication plan for ``goal`` via a model call."""
+
+    prompt = (
+        "Rewrite the goal '" + goal + "' into a concise public message and "
+        "identify the target audience. Respond as JSON with keys 'message' and "
+        "'audience'."
+    )
+    raw = providers.generate("cloud", prompt)
+    try:
+        data = json.loads(raw)
+    except Exception as exc:  # pragma: no cover - invalid model output
+        raise ValueError("Model did not return valid JSON") from exc
+    if not {"message", "audience"} <= data.keys():
+        raise ValueError("Model response missing fields")
+    return data  # type: ignore[return-value]

--- a/src/libreassistant/experts/devils_advocate.py
+++ b/src/libreassistant/experts/devils_advocate.py
@@ -1,6 +1,26 @@
-"""Devil's advocate analysis module."""
+"""Devil's advocate analysis module using a model call."""
+
+from __future__ import annotations
+
+import json
+from typing import Dict, List
+
+from ..providers import providers
 
 
-def analyze(goal: str) -> str:
-    """Highlight potential issues with the goal."""
-    return f"Potential issues with pursuing '{goal}'."
+def analyze(goal: str) -> Dict[str, List[str]]:
+    """Highlight potential issues with the goal via a language model."""
+
+    prompt = (
+        "List two potential risks or unintended consequences of the goal '"
+        + goal
+        + "'. Respond in JSON with a 'concerns' array of strings."
+    )
+    raw = providers.generate("cloud", prompt)
+    try:
+        data = json.loads(raw)
+    except Exception as exc:  # pragma: no cover - invalid model output
+        raise ValueError("Model did not return valid JSON") from exc
+    if "concerns" not in data or not isinstance(data["concerns"], list):
+        raise ValueError("Model response missing 'concerns'")
+    return data  # type: ignore[return-value]

--- a/src/libreassistant/experts/executive.py
+++ b/src/libreassistant/experts/executive.py
@@ -1,6 +1,25 @@
-"""Executive analysis module."""
+"""Executive analysis module backed by a language model."""
+
+from __future__ import annotations
+
+import json
+from typing import Dict, List
+
+from ..providers import providers
 
 
-def analyze(goal: str) -> str:
-    """Provide an executive breakdown of the goal."""
-    return f"Breakdown of '{goal}' into manageable tasks."
+def analyze(goal: str) -> Dict[str, List[str]]:
+    """Provide an executive breakdown of ``goal`` using model reasoning."""
+
+    prompt = (
+        "Break down the goal '" + goal + "' into three actionable steps. "
+        "Respond in JSON with a 'tasks' array of strings ordered sequentially."
+    )
+    raw = providers.generate("cloud", prompt)
+    try:
+        data = json.loads(raw)
+    except Exception as exc:  # pragma: no cover - invalid model output
+        raise ValueError("Model did not return valid JSON") from exc
+    if "tasks" not in data or not isinstance(data["tasks"], list):
+        raise ValueError("Model response missing 'tasks'")
+    return data  # type: ignore[return-value]

--- a/src/libreassistant/experts/research.py
+++ b/src/libreassistant/experts/research.py
@@ -1,6 +1,26 @@
-"""Research analysis module."""
+"""Research analysis module powered by a language model."""
+
+from __future__ import annotations
+
+import json
+from typing import Dict, List
+
+from ..providers import providers
 
 
-def analyze(goal: str) -> str:
-    """Return stubbed research findings for the goal."""
-    return f"Research findings for '{goal}' (stub)."
+def analyze(goal: str) -> Dict[str, List[str]]:
+    """Return lightweight research findings for the goal via model query."""
+
+    prompt = (
+        "Provide a brief research summary and a single citation for the goal '"
+        + goal
+        + "'. Respond in JSON with keys 'summary' and 'sources' (array of URLs)."
+    )
+    raw = providers.generate("cloud", prompt)
+    try:
+        data = json.loads(raw)
+    except Exception as exc:  # pragma: no cover - invalid model output
+        raise ValueError("Model did not return valid JSON") from exc
+    if not {"summary", "sources"} <= data.keys():
+        raise ValueError("Model response missing fields")
+    return data  # type: ignore[return-value]

--- a/src/libreassistant/experts/visualizer.py
+++ b/src/libreassistant/experts/visualizer.py
@@ -1,6 +1,27 @@
-"""Visualization analysis module."""
+"""Visualization analysis module powered by a model."""
+
+from __future__ import annotations
+
+import json
+from typing import Any, Dict
+
+from ..providers import providers
 
 
-def analyze(goal: str) -> str:
-    """Return a stub visualization description."""
-    return "Visualization not implemented in stub."
+def analyze(goal: str) -> Dict[str, Any]:
+    """Return visualization metadata and data for ``goal`` via model output."""
+
+    prompt = (
+        "For the goal '"
+        + goal
+        + "', propose a simple bar chart with phases and values. Respond as JSON "
+        + "{\"description\": str, \"data\": {\"type\": \"bar\", \"labels\": [str], \"values\": [number]}}."
+    )
+    raw = providers.generate("cloud", prompt)
+    try:
+        data = json.loads(raw)
+    except Exception as exc:  # pragma: no cover - invalid model output
+        raise ValueError("Model did not return valid JSON") from exc
+    if "description" not in data or "data" not in data:
+        raise ValueError("Model response missing fields")
+    return data

--- a/tests/test_think_tank_plugin.py
+++ b/tests/test_think_tank_plugin.py
@@ -1,7 +1,63 @@
 from typing import Any
-
+import json
+import pytest
 from libreassistant.plugins import think_tank
 from libreassistant.plugins.think_tank import ThinkTankPlugin
+
+
+MOCK_ANALYSIS = {
+    "summary": (
+        "The objective is to improve education. Stakeholders should collaborate on this initiative.\n"
+        "Argument: Improve education addresses an important societal need.; Investing in improve education can produce long-term benefits.; Improve education aligns with widely shared community values.\n"
+        "Caveats: Limited resources could hamper efforts to improve education.; There may be unintended consequences when attempting to improve education."
+    ),
+    "analysis": {
+        "goal": "Improve education",
+        "executive": {
+            "tasks": [
+                "Assess the current state related to improve education.",
+                "Develop a concrete plan to improve education.",
+                "Implement the plan and monitor progress.",
+            ]
+        },
+        "research": {
+            "summary": "Preliminary surveys on improve education indicate that multiple approaches have been proposed in academic and policy literature.",
+            "sources": ["https://example.org/research/improve_education"],
+        },
+        "devils_advocate": {
+            "concerns": [
+                "Limited resources could hamper efforts to improve education.",
+                "There may be unintended consequences when attempting to improve education.",
+            ]
+        },
+        "argument": {
+            "points": [
+                "Improve education addresses an important societal need.",
+                "Investing in improve education can produce long-term benefits.",
+                "Improve education aligns with widely shared community values.",
+            ]
+        },
+        "communications": {
+            "message": "The objective is to improve education. Stakeholders should collaborate on this initiative.",
+            "audience": "general public",
+        },
+        "visualizer": {
+            "description": "A bar chart visualizing stages to improve education.",
+            "data": {
+                "type": "bar",
+                "labels": ["Plan", "Execute", "Review"],
+                "values": [1, 2, 1],
+            },
+        },
+    },
+}
+
+
+@pytest.fixture(autouse=True)
+def mock_model_env(monkeypatch):
+    monkeypatch.setenv("THINK_TANK_MODEL_RESPONSE", json.dumps(MOCK_ANALYSIS))
+    yield
+    monkeypatch.delenv("THINK_TANK_MODEL_RESPONSE", raising=False)
 
 
 def test_thinktank_records_dossier() -> None:
@@ -10,7 +66,10 @@ def test_thinktank_records_dossier() -> None:
     payload = {"goal": "Improve education"}
     result = plugin.run(state, payload)
     assert "summary" in result
-    assert state["thinktank_dossier"][0]["goal"] == "Improve education"
+    dossier_entry = state["thinktank_dossier"][0]
+    assert dossier_entry["goal"] == "Improve education"
+    assert "tasks" in dossier_entry["executive"]
+    assert dossier_entry["visualizer"]["data"]["type"] == "bar"
 
 
 def test_thinktank_generates_realistic_summary() -> None:
@@ -20,9 +79,10 @@ def test_thinktank_generates_realistic_summary() -> None:
     assert "Argument:" in summary
     assert "Caveats:" in summary
     analysis = result["analysis"]
-    assert analysis["research"].startswith(
-        "Research findings for 'Improve education'"
+    assert analysis["research"]["summary"].startswith(
+        "Preliminary surveys on improve education"
     )
+    assert isinstance(analysis["argument"]["points"], list)
 
 
 def test_think_tank_integration(client) -> None:
@@ -39,4 +99,6 @@ def test_think_tank_integration(client) -> None:
     data = response.json()
     assert "summary" in data["result"]
     assert "Argument:" in data["result"]["summary"]
-    assert data["state"]["thinktank_dossier"][0]["goal"] == "Improve education"
+    entry = data["state"]["thinktank_dossier"][0]
+    assert entry["goal"] == "Improve education"
+    assert entry["visualizer"]["data"]["type"] == "bar"


### PR DESCRIPTION
## Summary
- Replace deterministic expert stubs with provider-based model calls
- Call language models from ThinkTank server with optional mocked responses
- Stub model output in tests via THINK_TANK_MODEL_RESPONSE for deterministic assertions

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a6092b106083328c126fb6d8452e9b