### PR TITLE
Persist history and audit logs via encrypted SQLite

### DIFF
--- a/src/libreassistant/__init__.py
+++ b/src/libreassistant/__init__.py
@@ -4,7 +4,8 @@
 """Core package for the LibreAssistant application."""
 
 from .kernel import kernel
+from . import db
 
-__all__ = ["__version__", "kernel"]
+__all__ = ["__version__", "kernel", "db"]
 
 __version__ = "0.1.0"

--- a/src/libreassistant/db.py
+++ b/src/libreassistant/db.py
@@ -1,0 +1,156 @@
+"""Lightweight SQLite database for history and audit logs."""
+
+from __future__ import annotations
+
+import json
+import os
+import pysqlcipher3.dbapi2 as sqlite3
+from pathlib import Path
+from typing import Any, Dict, List
+
+DB_PATH = Path(os.getenv("LIBRE_DB_PATH", "config/app.db"))
+DB_KEY = os.getenv("LIBRE_DB_KEY")
+HISTORY_RETENTION_DAYS = int(os.getenv("HISTORY_RETENTION_DAYS", "30"))
+AUDIT_RETENTION_DAYS = int(os.getenv("AUDIT_RETENTION_DAYS", "30"))
+
+_conn: sqlite3.Connection | None = None
+
+
+def get_conn() -> sqlite3.Connection:
+    global _conn
+    if _conn is None:
+        if not DB_KEY:
+            raise RuntimeError("LIBRE_DB_KEY environment variable must be set for encrypted database access")
+        DB_PATH.parent.mkdir(parents=True, exist_ok=True)
+        _conn = sqlite3.connect(str(DB_PATH), check_same_thread=False)
+        _conn.execute(f"PRAGMA key='{DB_KEY}'")
+        _initialize(_conn)
+    return _conn
+
+
+def _initialize(conn: sqlite3.Connection) -> None:
+    cur = conn.cursor()
+    cur.execute(
+        """
+        CREATE TABLE IF NOT EXISTS history (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            user_id TEXT NOT NULL,
+            timestamp DATETIME DEFAULT CURRENT_TIMESTAMP,
+            plugin TEXT NOT NULL,
+            payload TEXT NOT NULL,
+            granted INTEGER
+        )
+        """
+    )
+    cur.execute(
+        """
+        CREATE TABLE IF NOT EXISTS file_audit (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            user_id TEXT,
+            timestamp DATETIME DEFAULT CURRENT_TIMESTAMP,
+            action TEXT,
+            path TEXT
+        )
+        """
+    )
+    cur.execute(
+        "CREATE INDEX IF NOT EXISTS idx_history_user_time ON history(user_id, timestamp)"
+    )
+    cur.execute(
+        "CREATE INDEX IF NOT EXISTS idx_audit_user_time ON file_audit(user_id, timestamp)"
+    )
+    conn.commit()
+
+
+def clear() -> None:
+    """Remove all entries (used in tests)."""
+    conn = get_conn()
+    cur = conn.cursor()
+    cur.execute("DELETE FROM history")
+    cur.execute("DELETE FROM file_audit")
+    conn.commit()
+
+
+def prune_history() -> None:
+    conn = get_conn()
+    cur = conn.cursor()
+    cur.execute(
+        "DELETE FROM history WHERE timestamp < datetime('now', ?)",
+        (f'-{HISTORY_RETENTION_DAYS} days',),
+    )
+    conn.commit()
+
+
+def prune_audit() -> None:
+    conn = get_conn()
+    cur = conn.cursor()
+    cur.execute(
+        "DELETE FROM file_audit WHERE timestamp < datetime('now', ?)",
+        (f'-{AUDIT_RETENTION_DAYS} days',),
+    )
+    conn.commit()
+
+
+def add_history(user_id: str, plugin: str, payload: Dict[str, Any], granted: bool | None) -> None:
+    conn = get_conn()
+    prune_history()
+    cur = conn.cursor()
+    cur.execute(
+        "INSERT INTO history (user_id, plugin, payload, granted) VALUES (?, ?, ?, ?)",
+        (
+            user_id,
+            plugin,
+            json.dumps(payload),
+            int(granted) if granted is not None else None,
+        ),
+    )
+    conn.commit()
+
+
+def get_history(user_id: str) -> List[Dict[str, Any]]:
+    conn = get_conn()
+    cur = conn.cursor()
+    cur.execute(
+        "SELECT plugin, payload, granted FROM history WHERE user_id=? ORDER BY timestamp",
+        (user_id,),
+    )
+    rows = cur.fetchall()
+    result: List[Dict[str, Any]] = []
+    for plugin, payload, granted in rows:
+        entry: Dict[str, Any] = {
+            "plugin": plugin,
+            "payload": json.loads(payload),
+        }
+        if granted is not None:
+            entry["granted"] = bool(granted)
+        result.append(entry)
+    return result
+
+
+def add_file_audit(user_id: str | None, action: str | None, path: str | None) -> None:
+    conn = get_conn()
+    prune_audit()
+    cur = conn.cursor()
+    cur.execute(
+        "INSERT INTO file_audit (user_id, action, path) VALUES (?, ?, ?)",
+        (user_id, action, path),
+    )
+    conn.commit()
+
+
+def get_file_audit(user_id: str | None = None) -> List[Dict[str, Any]]:
+    conn = get_conn()
+    cur = conn.cursor()
+    if user_id is None:
+        cur.execute(
+            "SELECT user_id, action, path, timestamp FROM file_audit ORDER BY timestamp"
+        )
+    else:
+        cur.execute(
+            "SELECT user_id, action, path, timestamp FROM file_audit WHERE user_id=? ORDER BY timestamp",
+            (user_id,),
+        )
+    rows = cur.fetchall()
+    return [
+        {"user_id": u, "action": a, "path": p, "timestamp": t} for u, a, p, t in rows
+    ]

--- a/src/libreassistant/main.py
+++ b/src/libreassistant/main.py
@@ -21,6 +21,7 @@ from .providers.local import LocalConfig, LocalProvider
 from .transparency import HealthMonitor, get_bill_of_materials
 from .themes import get_theme_css
 from .vault import DataVault
+from . import db
 
 
 def create_app() -> FastAPI:
@@ -132,46 +133,23 @@ def create_app() -> FastAPI:
                 status_code=404, detail="Plugin not found"
             ) from exc
         state = kernel.get_state(request.user_id)
-        history = state.setdefault("history", [])
-        entry: Dict[str, Any] = {
-            "plugin": request.plugin,
-            "payload": request.payload,
-        }
-        if request.granted is not None:
-            entry["granted"] = request.granted
-        history.append(entry)
+        db.add_history(
+            request.user_id, request.plugin, request.payload, request.granted
+        )
         return {"result": result, "state": state}
 
     @app.get("/api/v1/history/{user_id}")
     def get_history(user_id: str) -> Dict[str, Any]:
         """Retrieve a user's past plugin invocations."""
-        state = kernel.get_state(user_id)
-        return {"history": state.get("history", [])}
+        return {"history": db.get_history(user_id)}
 
     @app.get("/api/v1/audit/file")
     def get_file_audit() -> Dict[str, Any]:
-        log_path = Path("logs/file_io_audit.ndjson")
-        if not log_path.exists():
-            return {"logs": []}
-        lines = [
-            json.loads(line)
-            for line in log_path.read_text().splitlines()
-            if line.strip()
-        ]
-        return {"logs": lines}
+        return {"logs": db.get_file_audit()}
 
     @app.get("/api/v1/audit/file/{user_id}")
     def get_file_audit_user(user_id: str) -> Dict[str, Any]:
-        log_path = Path("logs/file_io_audit.ndjson")
-        if not log_path.exists():
-            return {"logs": []}
-        lines = [
-            json.loads(line)
-            for line in log_path.read_text().splitlines()
-            if line.strip()
-        ]
-        filtered = [e for e in lines if e.get("user_id") == user_id]
-        return {"logs": filtered}
+        return {"logs": db.get_file_audit(user_id)}
 
     class HistoryEntry(BaseModel):
         plugin: str
@@ -180,15 +158,7 @@ def create_app() -> FastAPI:
 
     @app.post("/api/v1/history/{user_id}")
     def record_history(user_id: str, entry: HistoryEntry) -> Dict[str, str]:
-        state = kernel.get_state(user_id)
-        history = state.setdefault("history", [])
-        history.append(
-            {
-                "plugin": entry.plugin,
-                "payload": entry.payload,
-                "granted": entry.granted,
-            }
-        )
+        db.add_history(user_id, entry.plugin, entry.payload, entry.granted)
         return {"status": "ok"}
 
     @app.get("/api/v1/mcp/servers")

--- a/src/libreassistant/plugins/file_io.py
+++ b/src/libreassistant/plugins/file_io.py
@@ -5,29 +5,20 @@
 
 from __future__ import annotations
 
-import json
 import os
-from pathlib import Path
 from typing import Any, Dict, Literal, Tuple
 
 from pydantic import BaseModel, model_validator
 
 from ..kernel import kernel
 from ..mcp_adapter import MCPPluginAdapter
+from .. import db
 
 # Filesystem operations are restricted to this base directory. Paths
 # provided by users will be resolved relative to this directory and
 # rejected if they escape it. The default uses a "desktop" directory in
 # the user's home folder.
 ALLOWED_BASE_DIR = os.path.join(os.path.expanduser("~"), "desktop")
-
-AUDIT_LOG = Path("logs/file_io_audit.ndjson")
-
-
-def _write_audit(entry: Dict[str, Any]) -> None:
-    AUDIT_LOG.parent.mkdir(parents=True, exist_ok=True)
-    with AUDIT_LOG.open("a", encoding="utf-8") as fh:
-        fh.write(json.dumps(entry) + "\n")
 
 
 def _resolver(payload: Dict[str, Any]) -> Tuple[str, Dict[str, Any]]:
@@ -90,9 +81,7 @@ class FileIOPlugin(MCPPluginAdapter):
             user_state["last_file_path"] = resolved_path
             payload["path"] = resolved_path
             payload["user_id"] = user_id
-            _write_audit(
-                {"user_id": user_id, "action": payload.get("operation"), "path": resolved_path}
-            )
+            db.add_file_audit(user_id, payload.get("operation"), resolved_path)
         return super().run(user_state, payload)
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -17,6 +17,11 @@ from fastapi.testclient import TestClient
 # without installation.
 sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1] / "src"))
 
+import os
+
+os.environ["LIBRE_DB_PATH"] = ":memory:"
+os.environ["LIBRE_DB_KEY"] = "test-key"
+
 if shutil.which("node") is None:
     # Mock out MCP-based plugins when Node.js isn't available to keep tests
     # hermetic. These plugins would otherwise spawn a Node server during app
@@ -35,6 +40,7 @@ from libreassistant.plugins.echo import (  # noqa: E402
 from libreassistant.providers import providers  # noqa: E402
 from libreassistant.providers.cloud import CloudProvider  # noqa: E402
 from libreassistant.providers.local import LocalProvider  # noqa: E402
+from libreassistant import db as app_db  # noqa: E402
 
 
 @pytest.fixture
@@ -52,4 +58,5 @@ def reset_kernel() -> Generator[None, None, None]:
     providers.reset()
     providers.register("cloud", CloudProvider())
     providers.register("local", LocalProvider())
+    app_db.clear()
     yield

--- a/tests/test_db_encryption.py
+++ b/tests/test_db_encryption.py
@@ -1,0 +1,17 @@
+import importlib
+
+from libreassistant import db as app_db
+
+
+def test_database_file_is_encrypted(tmp_path, monkeypatch):
+    db_file = tmp_path / "enc.db"
+    monkeypatch.setenv("LIBRE_DB_PATH", str(db_file))
+    monkeypatch.setenv("LIBRE_DB_KEY", "secret-key")
+    importlib.reload(app_db)
+
+    app_db.add_history("bob", "test", {"data": "value"}, True)
+    app_db.get_history("bob")
+
+    data = db_file.read_bytes()
+    assert b"bob" not in data
+    assert b"value" not in data

--- a/tests/test_file_audit.py
+++ b/tests/test_file_audit.py
@@ -1,5 +1,4 @@
 from pathlib import Path
-import json
 
 from libreassistant.plugins import file_io
 
@@ -7,9 +6,6 @@ from libreassistant.plugins import file_io
 def test_file_audit_logging_and_endpoint(client, tmp_path: Path) -> None:
     file_io.ALLOWED_BASE_DIR = str(tmp_path)
     file_io.register()
-    log_file = Path("logs/file_io_audit.ndjson")
-    if log_file.exists():
-        log_file.unlink()
     path = tmp_path / "note.txt"
     resp = client.post(
         "/api/v1/invoke",
@@ -21,13 +17,6 @@ def test_file_audit_logging_and_endpoint(client, tmp_path: Path) -> None:
     )
     assert resp.status_code == 200
     assert resp.json()["result"] == {"status": "created"}
-    assert log_file.exists()
-    lines = [json.loads(line) for line in log_file.read_text().splitlines() if line.strip()]
-    assert len(lines) >= 2
-    assert any(
-        e["user_id"] == "alice" and e["action"] == "create" and e["path"] == str(path.resolve())
-        for e in lines
-    )
     resp_all = client.get("/api/v1/audit/file")
     assert resp_all.status_code == 200
     assert any(e["path"] == str(path.resolve()) for e in resp_all.json()["logs"])


### PR DESCRIPTION
## Summary
- encrypt history and audit log storage using SQLCipher-backed SQLite and a required `LIBRE_DB_KEY`
- set default test key and add unit test confirming no plaintext in the database file

## Testing
- `pytest tests/test_history.py tests/test_history_record.py tests/test_file_audit.py tests/test_db_encryption.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a612bd84748332aa99220df21de4bd