### PR TITLE
docs: document theme verification and metadata style guidelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,6 +33,7 @@ Join discussions in issues and pull requests to help shape the direction of the 
 Community themes live under the `community-themes/` directory. Themes override design tokens via CSS custom properties and are sanitized server-side to a whitelist of safe properties. To submit a new theme:
 
 1. Create a folder in `community-themes/` with your theme's name.
-2. Add a `metadata.json` file describing the theme and a `theme.css` stylesheet overriding tokens via CSS custom properties. Unsupported properties will be removed during sanitization.
+2. Add a `metadata.json` file describing the theme (follow the style guidelines in `community-themes/README.md`) and a `theme.css` stylesheet overriding tokens via CSS custom properties. Unsupported properties will be removed during sanitization.
 3. Run `python scripts/build_theme_catalog.py` to regenerate the catalog and sanitized styles.
-4. Include the generated changes in your pull request. The sanitized CSS will be served at `/api/v1/themes/{name}.css` for the marketplace to load in a sandboxed iframe.
+4. Open the generated `ui/themes/<id>.css` locally to verify the theme renders as expected.
+5. Include the generated changes in your pull request. The sanitized CSS will be served at `/api/v1/themes/{name}.css` for the marketplace to load in a sandboxed iframe.

--- a/community-themes/README.md
+++ b/community-themes/README.md
@@ -19,3 +19,38 @@ Submit pull requests that add a new folder with your theme files. The
 `ui/theme-catalog.json`, and writes the cleaned stylesheet to `ui/themes/`. The
 API exposes the sanitized CSS at `/api/v1/themes/{name}.css`, and the
 marketplace loads it in a sandboxed iframe with a strict Content Security Policy.
+
+## `metadata.json` Style Guide
+
+Each theme must include a `metadata.json` file with these fields:
+
+- `id`: Lowercase, dash-separated identifier matching the folder name.
+- `name`: Human-readable display name in Title Case.
+- `author`: Name or handle of the theme's creator.
+- `preview`: Hex color (`#RRGGBB` or `#RGB`) used for previews.
+- `rating`: Integer from `0`–`5` indicating relative contrast.
+
+Example:
+
+```json
+{
+  "id": "solarized",
+  "name": "Solarized",
+  "author": "Community",
+  "preview": "#fdf6e3",
+  "rating": 3
+}
+```
+
+## Verifying your theme
+
+Run the build script to sanitize your CSS and refresh the catalog:
+
+```bash
+python scripts/build_theme_catalog.py
+```
+
+This generates sanitized styles under `ui/themes/` and updates
+`ui/theme-catalog.json`. Open the resulting `ui/themes/<id>.css` in a browser or
+local build to confirm the theme renders as expected before submitting a pull
+request.


### PR DESCRIPTION
## Summary
- add metadata.json style guide and local theme verification instructions for community themes
- update contributing steps to verify generated theme and reference metadata guidelines

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'pysqlcipher3')*
- `npx -y markdownlint-cli '**/*.md'` *(fails: docs/law_api.md:42 MD012/no-multiple-blanks)*
- `python scripts/check_license_headers.py` *(fails: Missing MIT license header in multiple files)*

------
https://chatgpt.com/codex/tasks/task_e_68a62823d88c83328bb69e997f80a107