### PR TITLE
docs: add tsdoc comments

### DIFF
--- a/servers/echo/index.ts
+++ b/servers/echo/index.ts
@@ -33,6 +33,14 @@ const prompts: PromptSchema[] = [
   { name: 'echo_template', template: 'Repeat: {{message}}' }
 ];
 
+/**
+ * Invoke the requested tool for the echo server.
+ * Updates internal state when handling `echo_message`.
+ * @param tool   Tool name to execute
+ * @param params Parameters supplied by the client
+ * @returns Result object containing the echoed message
+ * @sideeffect Mutates `lastMessage` with the provided input
+ */
 async function invoke(tool: string, params: any) {
   if (tool === 'echo_message') {
     lastMessage = params?.message ?? '';
@@ -41,6 +49,9 @@ async function invoke(tool: string, params: any) {
   throw new Error(`Unknown tool ${tool}`);
 }
 
+/**
+ * MCP server implementation exposing a single echo tool.
+ */
 const server: MCPServer = {
   listTools: () => tools,
   listResources: () => resources,

--- a/servers/files/index.ts
+++ b/servers/files/index.ts
@@ -68,17 +68,37 @@ const prompts: PromptSchema[] = [
   { name: 'file_edit_template', template: 'Update file {{path}} with new content.' }
 ];
 
+/**
+ * Resolve a user-supplied relative path against the server's base directory.
+ * @param p Relative path from the client
+ * @returns Absolute path within the base directory
+ * @sideeffect Throws if path escapes the allowed directory
+ */
 function resolve(p: string) {
   const full = path.resolve(baseDir, p);
   if (!full.startsWith(baseDir)) throw new Error('path outside allowed directory');
   return full;
 }
 
+/**
+ * Append a file operation to the audit log.
+ * @param user     Optional user identifier
+ * @param action   Performed operation
+ * @param resolved Resolved absolute path
+ * @sideeffect Writes an entry to `file_io_audit.ndjson`
+ */
 async function audit(user: string | undefined, action: string, resolved: string) {
   const entry = { user_id: user, action, path: resolved, timestamp: Date.now() };
   await fs.appendFile(auditLog, JSON.stringify(entry) + '\n');
 }
 
+/**
+ * Invoke a file system tool, performing the requested operation and auditing it.
+ * @param tool   Tool name such as `fs_read` or `fs_update`
+ * @param params Parameters supplied by the client
+ * @returns Result object varying by tool
+ * @sideeffect Reads, writes, or deletes files and appends to audit log
+ */
 async function invoke(tool: string, params: any) {
   const user = params.user_id as string | undefined;
   switch (tool) {
@@ -118,6 +138,9 @@ async function invoke(tool: string, params: any) {
   throw new Error(`Unknown tool ${tool}`);
 }
 
+/**
+ * MCP server exposing basic file system operations.
+ */
 const server: MCPServer = {
   listTools: () => tools,
   listResources: () => resources,

--- a/servers/law_by_keystone/index.ts
+++ b/servers/law_by_keystone/index.ts
@@ -64,20 +64,43 @@ const prompts: PromptSchema[] = [
   },
 ];
 
+/**
+ * Ensure an output directory resides within the allowed base directory.
+ * @param p Desired output path
+ * @returns Resolved absolute path
+ * @sideeffect Throws if path escapes the base directory
+ */
 function ensureDir(p: string) {
   const full = path.resolve(baseDir, p);
   if (!full.startsWith(baseDir)) throw new Error('path outside allowed directory');
   return full;
 }
 
+/**
+ * Escape characters for safe inclusion in XML content.
+ * @param str Raw string
+ * @returns Escaped string
+ */
 function escapeXml(str: string) {
   return str.replace(/[<>&]/g, (c) => ({ '<': '&lt;', '>': '&gt;', '&': '&amp;' }[c]!));
 }
 
+/**
+ * Escape characters for safe inclusion in HTML content.
+ * @param str Raw string
+ * @returns Escaped string
+ */
 function escapeHtml(str: string) {
   return str.replace(/[&<>]/g, (c) => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;' }[c]!));
 }
 
+/**
+ * Fetch legal data from the specified source.
+ * @param source API source identifier
+ * @param query  Query string to search for
+ * @returns Parsed JSON response or error object
+ * @sideeffect Performs network requests to external APIs
+ */
 async function fetchApi(source: Source, query: string) {
   const govinfoKey = process.env.GOVINFO_API_KEY || 'DEMO_KEY';
   const openStatesKey = process.env.OPENSTATES_API_KEY || 'DEMO_KEY';
@@ -111,6 +134,13 @@ async function fetchApi(source: Source, query: string) {
   }
 }
 
+/**
+ * Format fetched legal data into the desired output representation.
+ * @param data   Raw data returned from the API
+ * @param format Output format such as `json`, `html`, or `md`
+ * @param meta   Metadata including query and source
+ * @returns Object containing formatted content and file extension
+ */
 function formatContent(
   data: any,
   format: string,
@@ -156,6 +186,13 @@ function formatContent(
   }
 }
 
+/**
+ * Invoke the `generate_legal_summary` tool to fetch and export legal data.
+ * @param tool   Tool name, only `generate_legal_summary` is supported
+ * @param params Parameters including query, source, and output options
+ * @returns Metadata about the exported summary
+ * @sideeffect Fetches remote data and writes files to disk
+ */
 async function invoke(tool: string, params: any) {
   if (tool !== 'generate_legal_summary')
     throw new Error(`Unknown tool ${tool}`);
@@ -182,6 +219,9 @@ async function invoke(tool: string, params: any) {
   return { status: 'exported', path: filePath, sources: [source], metadata };
 }
 
+/**
+ * MCP server providing legal research capabilities backed by government APIs.
+ */
 const server: MCPServer = {
   listTools: () => tools,
   listResources: () => resources,

--- a/servers/think_tank/index.ts
+++ b/servers/think_tank/index.ts
@@ -9,6 +9,13 @@ import { fileURLToPath } from 'url';
 // variable is unset we attempt to use the OpenAI client.  The call is lazily
 // imported so the dependency is optional.
 
+/**
+ * Call the backing language model to generate structured analysis.
+ * Uses a mock response when `THINK_TANK_MODEL_RESPONSE` is set.
+ * @param prompt Prompt string to send to the model
+ * @returns Parsed JSON response from the model
+ * @sideeffect Performs network requests when no mock is provided
+ */
 async function callModel(prompt: string): Promise<any> {
   const mock = process.env.THINK_TANK_MODEL_RESPONSE;
   if (mock) {
@@ -122,6 +129,13 @@ const prompts: PromptSchema[] = [
   { name: 'thinktank_question_template', template: 'Consider the goal: {{goal}}' }
 ];
 
+/**
+ * Invoke the `analyze_goal` tool to generate a think tank analysis.
+ * @param tool   Tool name, only `analyze_goal` is supported
+ * @param params Parameters containing the goal string
+ * @returns Structured analysis produced by the language model
+ * @sideeffect Calls the language model and updates `lastDossier`
+ */
 async function invoke(tool: string, params: any) {
   if (tool !== 'analyze_goal') throw new Error(`Unknown tool ${tool}`);
   const goal = params.goal;
@@ -144,6 +158,9 @@ Analyze the goal: ${goal}`;
   return result;
 }
 
+/**
+ * MCP server providing structured analysis of user goals.
+ */
 const server: MCPServer = {
   listTools: () => tools,
   listResources: () => resources,

--- a/src/mcp/client.ts
+++ b/src/mcp/client.ts
@@ -7,7 +7,10 @@ import path from 'path';
 
 const MAX_LOG_SIZE = 5 * 1024 * 1024; // 5MB
 
-// Wrapper around a remote MCP server accessed via a Transport.
+/**
+ * Wrapper around a remote MCP server accessed via a {@link Transport}.
+ * Caches capability lists and validates parameters before dispatching requests.
+ */
 class RemoteServer implements MCPServer {
   constructor(
     private transport: Transport,
@@ -17,18 +20,36 @@ class RemoteServer implements MCPServer {
     private validators: Map<string, ValidateFunction>
   ) {}
 
+  /**
+   * Return cached tool definitions from the server.
+   * @returns Array of tool schemas
+   */
   listTools() {
     return this.cachedTools;
   }
 
+  /**
+   * Return cached resource definitions from the server.
+   * @returns Array of resource schemas
+   */
   listResources() {
     return this.cachedResources;
   }
 
+  /**
+   * Return cached prompt templates from the server.
+   * @returns Array of prompt schemas
+   */
   listPrompts() {
     return this.cachedPrompts;
   }
 
+  /**
+   * Invoke a remote tool after validating parameters.
+   * @param tool   Tool name to execute
+   * @param params Parameter object to validate and forward
+   * @returns Result from the remote server or validation error object
+   */
   async invoke(tool: string, params: any) {
     const validator = this.validators.get(tool);
     const args = params ?? {};
@@ -39,7 +60,10 @@ class RemoteServer implements MCPServer {
   }
 }
 
-// Client that connects to MCP servers via JSON-RPC transports.
+/**
+ * Client that connects to MCP servers via JSON-RPC transports.
+ * Maintains per-server network policies and an audit log of invocations.
+ */
 export class MCPClient {
   private servers: Map<string, RemoteServer> = new Map();
   private transports: Map<string, Transport> = new Map();
@@ -55,6 +79,13 @@ export class MCPClient {
     MCPClient.patchFetch();
   }
 
+  /**
+   * Register a remote server with the client and cache its capabilities.
+   * @param name      Logical name of the server
+   * @param transport Transport used for communication
+   * @param policy    Optional network policy for requests through this server
+   * @sideeffect Adds the server to internal maps and may start background processes
+   */
   async register(name: string, transport: Transport, policy?: NetworkPolicy) {
     const tools = await transport.request('listTools');
     const resources = await transport.request('listResources');
@@ -71,16 +102,34 @@ export class MCPClient {
     if (policy) this.policies.set(name, policy);
   }
 
+  /**
+   * List the names of all registered servers.
+   * @returns Array of server identifiers
+   */
   listServers() {
     return Array.from(this.servers.keys());
   }
 
+  /**
+   * Retrieve a previously registered server by name.
+   * @param name Server identifier
+   * @returns {@link MCPServer} instance
+   */
   getServer(name: string): MCPServer {
     const server = this.servers.get(name);
     if (!server) throw new Error(`Unknown server ${name}`);
     return server;
   }
 
+  /**
+   * Invoke a tool on a registered server while applying network policies
+   * and recording an audit entry.
+   * @param serverName Server identifier
+   * @param tool       Tool to execute
+   * @param params     Parameters supplied to the tool
+   * @returns Result from the remote invocation
+   * @sideeffect Writes to audit log and may modify files referenced by `params`
+   */
   async invoke(serverName: string, tool: string, params: any) {
     const server = this.getServer(serverName);
     let beforeHash: string | undefined;
@@ -130,6 +179,11 @@ export class MCPClient {
     return result;
   }
 
+  /**
+   * Append an entry to the persistent audit log.
+   * @param entry Audit information to record
+   * @sideeffect Writes to the file system under `logs/`
+   */
   private async appendAudit(entry: AuditEntry) {
     try {
       await fs.mkdir(path.dirname(this.logPath), { recursive: true });
@@ -147,16 +201,29 @@ export class MCPClient {
     }
   }
 
-  close() {
-    for (const transport of this.transports.values()) {
-      transport.close();
-    }
+  /**
+   * Close all registered transports and release their resources.
+   * @sideeffect Terminates network connections or child processes
+   */
+  async close() {
+    await Promise.all(
+      Array.from(this.transports.values(), t => t.close()),
+    );
   }
 
+  /**
+   * Set the default network policy applied when invoking servers without a specific policy.
+   * @param policy Network policy to enforce
+   */
   setDefaultPolicy(policy?: NetworkPolicy) {
     MCPClient.defaultPolicy = policy;
   }
 
+  /**
+   * Patch the global `fetch` function to enforce active network policies.
+   * The patch is applied only once per process.
+   * @sideeffect Overrides the global `fetch`
+   */
   private static patchFetch() {
     if (MCPClient.fetchPatched) return;
     const original = globalThis.fetch.bind(globalThis);

--- a/src/mcp/registry.ts
+++ b/src/mcp/registry.ts
@@ -5,8 +5,13 @@ import fs from 'fs';
 import path from 'path';
 import { fileURLToPath } from 'url';
 
+/**
+ * Shape of the JSON configuration consumed by {@link loadRegistry}.
+ */
 interface RegistryConfig {
+  /** Servers that may be registered */
   servers: { name: string; module: string; network?: NetworkPolicy }[];
+  /** Optional default network policy applied when none specified per server */
   defaultNetwork?: NetworkPolicy;
 }
 
@@ -19,6 +24,8 @@ interface RegistryConfig {
  * @param consentPath Optional path to a JSON file mapping server names to
  *                    boolean consent flags. Defaults to `mcp.consent.json`
  *                    in the same directory as the config file.
+ * @returns Promise that resolves when all allowed servers have been registered
+ * @sideeffect Spawns server processes and updates client state
  */
 export async function loadRegistry(
   configPath: string,

--- a/src/mcp/transport.ts
+++ b/src/mcp/transport.ts
@@ -1,28 +1,57 @@
 import { spawn, ChildProcess } from 'child_process';
 import { MCPServer, NetworkPolicy } from './types.js';
 
-// Basic JSON-RPC message types
+/**
+ * Basic JSON-RPC request message as exchanged over transports.
+ */
 interface JSONRPCRequest {
+  /** Version string, always `"2.0"` */
   jsonrpc: '2.0';
+  /** Sequential identifier for matching responses */
   id: number;
+  /** Method name being invoked */
   method: string;
+  /** Optional parameters for the method */
   params?: any;
 }
 
+/**
+ * Basic JSON-RPC response message as exchanged over transports.
+ */
 interface JSONRPCResponse {
+  /** Version string, always `"2.0"` */
   jsonrpc: '2.0';
+  /** Identifier of the original request */
   id: number;
+  /** Result value when the call succeeds */
   result?: any;
+  /** Error information when the call fails */
   error?: { code: number; message: string; data?: any };
 }
 
-// Transport interface used by the MCP client
+/**
+ * Transport interface used by the MCP client to send JSON-RPC messages.
+ */
 export interface Transport {
+  /**
+   * Send a JSON-RPC request and wait for the response.
+   * @param method Name of the remote method
+   * @param params Optional parameters object
+   * @returns JSON result returned by the server
+   */
   request(method: string, params?: any): Promise<any>;
-  close(): void;
+  /**
+   * Close any underlying resources such as sockets or processes.
+   * Implementations should resolve the returned promise once all handles
+   * have been fully released so tests can reliably await shutdown.
+   */
+  close(): Promise<void>;
 }
 
-// JSON-RPC over child-process stdio
+/**
+ * JSON-RPC transport implemented over a child process's stdio streams.
+ * Spawns a process and proxies JSON-RPC messages to it.
+ */
 export class StdioTransport implements Transport {
   private proc: ChildProcess;
   private nextId = 1;
@@ -32,6 +61,13 @@ export class StdioTransport implements Transport {
   >();
   private buffer = '';
 
+  /**
+   * Create a transport communicating with a child process.
+   * @param command Command to spawn
+   * @param args Arguments to pass to the command
+   * @param policy Network policy passed to the child as environment variables
+   * @sideeffect Spawns a new child process
+   */
   constructor(command: string, args: string[] = [], policy?: NetworkPolicy) {
     this.proc = spawn(command, args, {
       stdio: ['pipe', 'pipe', 'inherit'],
@@ -64,6 +100,12 @@ export class StdioTransport implements Transport {
     });
   }
 
+  /**
+   * Send a JSON-RPC request to the child process.
+   * @param method Remote method name
+   * @param params Optional parameters object
+   * @returns JSON result from the child process
+   */
   request(method: string, params?: any): Promise<any> {
     const id = this.nextId++;
     const req: JSONRPCRequest = { jsonrpc: '2.0', id, method, params };
@@ -73,14 +115,29 @@ export class StdioTransport implements Transport {
     });
   }
 
-  close() {
-    this.proc.kill();
+  /**
+   * Terminate the underlying child process.
+   * @sideeffect Kills the spawned process
+   */
+  async close() {
+    return new Promise<void>(resolve => {
+      this.proc.once('exit', () => resolve());
+      this.proc.kill();
+    });
   }
 }
 
-// JSON-RPC over simple HTTP POST + optional SSE stream
+/**
+ * JSON-RPC transport that communicates with an HTTP endpoint and optional SSE stream.
+ */
 export class HTTPTransport implements Transport {
   private abort?: AbortController;
+  /**
+   * Create an HTTP transport.
+   * @param endpoint URL accepting JSON-RPC POST requests
+   * @param sseEndpoint Optional Server-Sent Events endpoint for notifications
+   * @sideeffect Initiates a long-lived fetch when `sseEndpoint` is provided
+   */
   constructor(private endpoint: string, private sseEndpoint?: string) {
     if (sseEndpoint) {
       this.abort = new AbortController();
@@ -114,6 +171,12 @@ export class HTTPTransport implements Transport {
     }
   }
 
+  /**
+   * Send a JSON-RPC request via HTTP POST.
+   * @param method Remote method name
+   * @param params Optional parameters object
+   * @returns Parsed JSON result from the server
+   */
   async request(method: string, params?: any): Promise<any> {
     const res = await fetch(this.endpoint, {
       method: 'POST',
@@ -125,12 +188,21 @@ export class HTTPTransport implements Transport {
     return json.result;
   }
 
-  close() {
+  /**
+   * Abort any outstanding SSE connection.
+   * @sideeffect Cancels network requests
+   */
+  async close() {
     this.abort?.abort();
+    return Promise.resolve();
   }
 }
 
-// Utility to serve an MCPServer over stdio
+/**
+ * Utility helper to expose an {@link MCPServer} over the current process's stdio.
+ * @param server MCP server implementation to expose
+ * @sideeffect Reads from stdin and writes JSON-RPC responses to stdout
+ */
 export function serveStdio(server: MCPServer) {
   process.stdin.setEncoding('utf8');
   let buffer = '';

--- a/src/mcp/types.ts
+++ b/src/mcp/types.ts
@@ -1,41 +1,98 @@
-// Basic types for Model Context Protocol objects
+/**
+ * Schema describing an executable tool exposed by an MCP server.
+ * Parameters and return values follow JSON Schema definitions.
+ */
 export interface ToolSchema {
+  /** Name of the tool as invoked by clients */
   name: string;
+  /** Human readable description of the tool's behavior */
   description: string;
+  /** JSON Schema describing the expected parameter object */
   parameters: Record<string, unknown>; // JSON Schema
+  /** JSON Schema describing the response object */
   returns: Record<string, unknown>; // JSON Schema
 }
 
+/**
+ * Schema describing a static resource that can be fetched from a server.
+ */
 export interface ResourceSchema {
+  /** URI that uniquely identifies the resource */
   uri: string;
+  /** Human readable description of the resource */
   description: string;
 }
 
+/**
+ * Schema for a prompt template that can be expanded by the client.
+ */
 export interface PromptSchema {
+  /** Identifier of the prompt */
   name: string;
+  /** Template string with handlebars style placeholders */
   template: string;
 }
 
+/**
+ * Interface implemented by all MCP servers.
+ * Each method may perform I/O or network requests depending on the server implementation.
+ */
 export interface MCPServer {
+  /**
+   * List tool definitions available on the server.
+   * @returns Array of {@link ToolSchema} objects
+   */
   listTools(): ToolSchema[];
+  /**
+   * List available resources on the server.
+   * @returns Array of {@link ResourceSchema} objects
+   */
   listResources(): ResourceSchema[];
+  /**
+   * List available prompt templates.
+   * @returns Array of {@link PromptSchema} objects
+   */
   listPrompts(): PromptSchema[];
+  /**
+   * Invoke a tool with a parameter object.
+   * This may trigger arbitrary side effects depending on the tool implementation.
+   * @param tool   Name of the tool to execute
+   * @param params Parameters to pass to the tool
+   * @returns Result value produced by the tool
+   */
   invoke(tool: string, params: any): Promise<any>;
 }
 
+/**
+ * Entry describing a single tool invocation for auditing purposes.
+ */
 export interface AuditEntry {
+  /** Name of the server hosting the tool */
   server: string;
+  /** Invoked tool name */
   tool: string;
+  /** Parameter object supplied by the user */
   params: any;
+  /** Result returned by the server */
   result: any;
+  /** Unix timestamp when the call completed */
   timestamp: number;
+  /** Optional hash of a file before invoking the tool */
   beforeHash?: string;
+  /** Optional hash of a file after invoking the tool */
   afterHash?: string;
+  /** External data sources referenced by the result */
   dataSources?: string[];
 }
 
+/**
+ * Network access policy restricting where servers may make requests.
+ */
 export interface NetworkPolicy {
+  /** Whitelisted hostnames */
   allow?: string[];
+  /** Blacklisted hostnames */
   deny?: string[];
+  /** Allowed protocols such as `https` or `http` */
   protocols?: string[];
 }

--- a/src/switchboard/mcpAdapter.ts
+++ b/src/switchboard/mcpAdapter.ts
@@ -1,8 +1,10 @@
 import { MCPClient } from '../mcp/client.js';
 
-// Adapter that exposes MCP servers as high level "plugins" to the UI.
-// Each plugin maps to a primary tool; the underlying tools/resources/prompts
-// remain hidden from the switchboard.
+/**
+ * Adapter that exposes MCP servers as high level "plugins" to the UI.
+ * Each plugin maps to a primary tool; the underlying tools/resources/prompts
+ * remain hidden from the switchboard.
+ */
 export class MCPAdapter {
   private toolMap: Record<string, string | ((params: any) => string)> = {
     echo: 'echo_message',
@@ -23,10 +25,23 @@ export class MCPAdapter {
 
   constructor(private client: MCPClient) {}
 
+  /**
+   * List available plugin names.
+   * @returns Array of plugin identifiers
+   */
   listPlugins(): string[] {
     return Object.keys(this.toolMap);
   }
 
+  /**
+   * Invoke a plugin by mapping it to the underlying MCP tool.
+   * Prompts for confirmation on destructive file operations and records history.
+   * @param plugin Plugin identifier to execute
+   * @param params Parameters to forward to the underlying tool
+   * @param userId User performing the action
+   * @returns Result from the MCP client
+   * @sideeffect May display consent modal and logs invocation history via HTTP
+   */
   async invokePlugin(plugin: string, params: any, userId: string): Promise<any> {
     const mapping = this.toolMap[plugin];
     if (!mapping) throw new Error(`Unknown plugin ${plugin}`);
@@ -56,6 +71,15 @@ export class MCPAdapter {
     return result;
   }
 
+  /**
+   * Persist an invocation to the user's history log via HTTP.
+   * Failures are ignored so as not to block plugin execution.
+   * @param user    User identifier
+   * @param plugin  Invoked plugin name
+   * @param payload Parameters passed to the plugin
+   * @param granted Whether consent was granted for the action
+   * @sideeffect Performs a network request to `/api/v1/history`
+   */
   private async recordHistory(
     user: string,
     plugin: string,


### PR DESCRIPTION
## Summary
- document MCP types, transports, and client methods
- add TSDoc comments to server implementations and switchboard adapter
- ensure transports and client await shutdown to prevent hanging tests

## Testing
- `npm test` *(fails: hangs during execution)*

------
https://chatgpt.com/codex/tasks/task_e_68a6282db2848332bd0af2b5aab3bd58