### PR TITLE
docs: document personal data vault

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,6 +33,7 @@ Join discussions in issues and pull requests to help shape the direction of the 
 Community themes live under the `community-themes/` directory. Themes override design tokens via CSS custom properties and are sanitized server-side to a whitelist of safe properties. To submit a new theme:
 
 1. Create a folder in `community-themes/` with your theme's name.
-2. Add a `metadata.json` file describing the theme and a `theme.css` stylesheet overriding tokens via CSS custom properties. Unsupported properties will be removed during sanitization.
+2. Add a `metadata.json` file describing the theme (follow the style guidelines in `community-themes/README.md`) and a `theme.css` stylesheet overriding tokens via CSS custom properties. Unsupported properties will be removed during sanitization.
 3. Run `python scripts/build_theme_catalog.py` to regenerate the catalog and sanitized styles.
-4. Include the generated changes in your pull request. The sanitized CSS will be served at `/api/v1/themes/{name}.css` for the marketplace to load in a sandboxed iframe.
+4. Open the generated `ui/themes/<id>.css` locally to verify the theme renders as expected.
+5. Include the generated changes in your pull request. The sanitized CSS will be served at `/api/v1/themes/{name}.css` for the marketplace to load in a sandboxed iframe.

--- a/README.md
+++ b/README.md
@@ -62,6 +62,9 @@ LibreAssistant ships with adapters for both hosted and local models.  The
 following environment variables control defaults and simple per-minute rate
 limits.  A value of `0` disables throttling.
 
+Additional configuration details and API key endpoints are documented in
+[docs/providers.md](docs/providers.md).
+
 | Provider | Variables |
 | --- | --- |
 | OpenAI | `OPENAI_MODEL`, `OPENAI_MAX_TOKENS`, `OPENAI_TEMPERATURE`, `OPENAI_RATE_LIMIT` |

--- a/README.md
+++ b/README.md
@@ -158,6 +158,7 @@ dashboards track each request so you can inspect how outputs were produced.
 ## Further Reading
 
 - [docs/api.md](docs/api.md) – REST API endpoints
+- [docs/data-vault.md](docs/data-vault.md) – consent workflow and storage details
 - [ARCHITECTURE.md](ARCHITECTURE.md) – system flows and design goals
 - [OVERVIEW.md](OVERVIEW.md) – background on the Model Context Protocol
 - [docs/network-policy.md](docs/network-policy.md) – configuring server network policies

--- a/community-themes/README.md
+++ b/community-themes/README.md
@@ -19,3 +19,38 @@ Submit pull requests that add a new folder with your theme files. The
 `ui/theme-catalog.json`, and writes the cleaned stylesheet to `ui/themes/`. The
 API exposes the sanitized CSS at `/api/v1/themes/{name}.css`, and the
 marketplace loads it in a sandboxed iframe with a strict Content Security Policy.
+
+## `metadata.json` Style Guide
+
+Each theme must include a `metadata.json` file with these fields:
+
+- `id`: Lowercase, dash-separated identifier matching the folder name.
+- `name`: Human-readable display name in Title Case.
+- `author`: Name or handle of the theme's creator.
+- `preview`: Hex color (`#RRGGBB` or `#RGB`) used for previews.
+- `rating`: Integer from `0`–`5` indicating relative contrast.
+
+Example:
+
+```json
+{
+  "id": "solarized",
+  "name": "Solarized",
+  "author": "Community",
+  "preview": "#fdf6e3",
+  "rating": 3
+}
+```
+
+## Verifying your theme
+
+Run the build script to sanitize your CSS and refresh the catalog:
+
+```bash
+python scripts/build_theme_catalog.py
+```
+
+This generates sanitized styles under `ui/themes/` and updates
+`ui/theme-catalog.json`. Open the resulting `ui/themes/<id>.css` in a browser or
+local build to confirm the theme renders as expected before submitting a pull
+request.

--- a/docs/api.md
+++ b/docs/api.md
@@ -7,27 +7,185 @@ LibreAssistant exposes a FastAPI service with endpoints for plugin invocation, u
 ## Invocation
 - `POST /api/v1/invoke` – invoke a registered plugin
 
+  ```bash
+  curl -X POST http://localhost:8000/api/v1/invoke \
+    -H "Content-Type: application/json" \
+    -d '{"plugin":"echo","user_id":"alice","payload":{"text":"hi"}}'
+  ```
+
+  ```json
+  {
+    "result": {"text": "hi"},
+    "state": {"history": []}
+  }
+  ```
+
 ## History
 - `GET /api/v1/history/{user_id}` – return a user's past plugin invocations
 
+  ```bash
+  curl http://localhost:8000/api/v1/history/alice
+  ```
+
+  ```json
+  {
+    "history": [
+      {"plugin": "echo", "payload": {"text": "hi"}, "granted": true}
+    ]
+  }
+  ```
+
 ## Audit
 - `GET /api/v1/audit/file` – return file operation audit logs
+
+  ```bash
+  curl http://localhost:8000/api/v1/audit/file
+  ```
+
+  ```json
+  {
+    "logs": [
+      {
+        "user_id": "alice",
+        "action": "read",
+        "path": "/tmp/example.txt",
+        "timestamp": "2024-01-01T00:00:00Z"
+      }
+    ]
+  }
+  ```
+
 - `GET /api/v1/audit/file/{user_id}` – return file operation logs for a user
+
+  ```bash
+  curl http://localhost:8000/api/v1/audit/file/alice
+  ```
+
+  ```json
+  {
+    "logs": [
+      {
+        "action": "read",
+        "path": "/tmp/example.txt",
+        "timestamp": "2024-01-01T00:00:00Z"
+      }
+    ]
+  }
+  ```
 
 ## Personal Data Vault
 - `POST /api/v1/vault/{user_id}` – store data
+
+  ```bash
+  curl -X POST http://localhost:8000/api/v1/vault/alice \
+    -H "Content-Type: application/json" \
+    -d '{"data":{"email":"alice@example.com"}}'
+  ```
+
+  ```json
+  { "status": "ok" }
+  ```
+
+  Error cases:
+  - `403` if consent not granted.
+
 - `GET /api/v1/vault/{user_id}` – retrieve stored data
+
+  ```bash
+  curl http://localhost:8000/api/v1/vault/alice
+  ```
+
+  ```json
+  { "data": { "email": "alice@example.com" } }
+  ```
+
+  Error cases:
+  - `403` if consent not granted.
+
 - `GET /api/v1/vault/{user_id}/export` – export stored data
+
+  ```bash
+  curl http://localhost:8000/api/v1/vault/alice/export
+  ```
+
+  ```json
+  { "data": { "email": "alice@example.com" } }
+  ```
+
+  Error cases:
+  - `403` if consent not granted.
+
 - `DELETE /api/v1/vault/{user_id}` – delete stored data
+
+  ```bash
+  curl -X DELETE http://localhost:8000/api/v1/vault/alice
+  ```
+
+  ```json
+  { "status": "deleted" }
+  ```
+
+  Error cases:
+  - `403` if consent not granted.
+
 - `POST /api/v1/consent/{user_id}` – set consent flag
+
+  ```bash
+  curl -X POST http://localhost:8000/api/v1/consent/alice \
+    -H "Content-Type: application/json" \
+    -d '{"consent": true}'
+  ```
+
+  ```json
+  { "status": "ok" }
+  ```
+
+  Error cases:
+  - `400` if `consent` field missing.
+
 - `GET /api/v1/consent/{user_id}` – get consent status
+  ```bash
+  curl http://localhost:8000/api/v1/consent/alice
+  ```
+
+  ```json
+  { "consent": true }
+  ```
 
 See [data-vault.md](data-vault.md) for consent workflow, storage format, key
 rotation, and security implications.
 
 ## Provider Integration
 - `POST /api/v1/providers/{name}/key` – configure an API key for a provider
+
+  ```bash
+  curl -X POST http://localhost:8000/api/v1/providers/openai/key \
+    -H "Content-Type: application/json" \
+    -d '{"key":"sk-..."}'
+  ```
+
+  ```json
+  { "status": "ok" }
+  ```
+
+  Error cases:
+  - `400` if `key` field missing.
+
 - `POST /api/v1/generate` – generate a response using the specified provider
+
+  ```bash
+  curl -X POST http://localhost:8000/api/v1/generate \
+    -H "Content-Type: application/json" \
+    -d '{"provider":"openai","prompt":"Hello"}'
+  ```
+
+  ```json
+  { "result": "Hi!" }
+  ```
+
+  Error cases:
+  - `404` if provider not found.
+  - `400` for invalid prompt or configuration.
 
 ### Configuration
 
@@ -45,10 +203,41 @@ model with `ollama run llama2`, or adjust the `LOCAL_` variables to point to a
 different server or model.
 
 ## MCP Registry
-- `GET /api/v1/mcp/servers` – list servers from the MCP registry and their
-  consent status
+- `GET /api/v1/mcp/servers` – list servers from the MCP registry and their consent status
+
+  ```bash
+  curl http://localhost:8000/api/v1/mcp/servers
+  ```
+
+  ```json
+  { "servers": [ { "name": "echo", "consent": true } ] }
+  ```
+
 - `POST /api/v1/mcp/consent/{name}` – set consent for an MCP server
+
+  ```bash
+  curl -X POST http://localhost:8000/api/v1/mcp/consent/echo \
+    -H "Content-Type: application/json" \
+    -d '{"consent": false}'
+  ```
+
+  ```json
+  { "status": "ok" }
+  ```
+
+  Error cases:
+  - `400` if `consent` field missing.
+  - `404` if server not found.
+
 - `GET /api/v1/mcp/consent/{name}` – get consent for an MCP server
+
+  ```bash
+  curl http://localhost:8000/api/v1/mcp/consent/echo
+  ```
+
+  ```json
+  { "consent": false }
+  ```
 
 Registry entries may include a `network` object describing `allow`, `deny`, and
 `protocols` lists. A `defaultNetwork` policy applies to servers without explicit
@@ -57,7 +246,41 @@ rules. These settings control which hosts and protocols a server may access.
 ## Themes
 - `GET /api/v1/themes/{theme_id}.css` – return sanitized CSS for a theme. The response is served with a strict `Content-Security-Policy` header.
 
+  ```bash
+  curl http://localhost:8000/api/v1/themes/dark.css
+  ```
+
+  ```css
+  body { background: #000; color: #fff; }
+  ```
+
+  Error cases:
+  - `404` if theme not found.
+
 ## Transparency
-- `GET /api/v1/bom` – list application dependencies, installed models, and datasets. The endpoint scans
-  directories specified by `LA_MODELS_DIR` and `LA_DATASETS_DIR` (defaulting to `models/` and `datasets/`).
+- `GET /api/v1/bom` – list application dependencies, installed models, and datasets. The endpoint scans directories specified by `LA_MODELS_DIR` and `LA_DATASETS_DIR` (defaulting to `models/` and `datasets/`).
+
+  ```bash
+  curl http://localhost:8000/api/v1/bom
+  ```
+
+  ```json
+  {
+    "dependencies": ["fastapi", "uvicorn"],
+    "models": [],
+    "datasets": []
+  }
+  ```
+
 - `GET /api/v1/health` – expose request counts and runtime metrics
+
+  ```bash
+  curl http://localhost:8000/api/v1/health
+  ```
+
+  ```json
+  {
+    "requests": 42,
+    "uptime": 3600
+  }
+  ```

--- a/docs/api.md
+++ b/docs/api.md
@@ -22,6 +22,9 @@ LibreAssistant exposes a FastAPI service with endpoints for plugin invocation, u
 - `POST /api/v1/consent/{user_id}` – set consent flag
 - `GET /api/v1/consent/{user_id}` – get consent status
 
+See [data-vault.md](data-vault.md) for consent workflow, storage format, key
+rotation, and security implications.
+
 ## Provider Integration
 - `POST /api/v1/providers/{name}/key` – configure an API key for a provider
 - `POST /api/v1/generate` – generate a response using the specified provider

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,59 @@
+<!-- Copyright (c) 2024 LibreAssistant contributors. Licensed under the MIT License. -->
+
+# MCP Configuration
+
+LibreAssistant's Model Context Protocol (MCP) client uses configuration files to
+control which servers are available and what network access they have.
+
+## Registry file (`mcp.registry.json`)
+
+The registry enumerates all MCP servers and optional network policies.
+
+```json
+{
+  "defaultNetwork": { "allow": ["localhost"] },
+  "servers": [
+    {
+      "name": "files",
+      "module": "./servers/files/index.ts",
+      "network": {
+        "allow": ["localhost"],
+        "deny": ["example.com"],
+        "protocols": ["https"]
+      }
+    }
+  ]
+}
+```
+
+- **defaultNetwork** – optional object that sets global `allow`, `deny`, and
+  `protocols` lists applied to every server that does not provide its own rules.
+- **servers** – array where each entry defines:
+  - **name** – unique identifier for the server.
+  - **module** – path to the server implementation.
+  - **network** – optional object overriding the default policy with `allow`,
+    `deny`, and `protocols` lists of hosts and URL schemes the server may reach.
+
+## Consent file (`mcp.consent.json`)
+
+Consent information is stored separately:
+
+```json
+{ "files": true, "law_by_keystone": false }
+```
+
+The file is a simple mapping from server name to a boolean indicating whether the
+user or administrator has granted permission for the client to load that server.
+
+## Interaction of consent and network policies
+
+When the MCP client starts it reads `mcp.registry.json` and `mcp.consent.json`.
+Only servers with a `true` flag in the consent file are registered. For each
+registered server the client's network policy is set to the server's `network`
+configuration (or `defaultNetwork` if none is provided). Both the client and the
+spawned server process enforce these rules, ensuring non‑consented servers are
+never started and consented servers can only access allowed hosts using
+permitted protocols.
+
+See [network-policy.md](./network-policy.md) for more details on network
+restrictions.

--- a/docs/data-vault.md
+++ b/docs/data-vault.md
@@ -1,0 +1,39 @@
+<!-- Copyright (c) 2024 LibreAssistant contributors. Licensed under the MIT License. -->
+
+# Personal Data Vault
+
+LibreAssistant ships with a personal data vault for storing information generated
+by plugins or uploaded by users. The vault encrypts records at rest and requires
+explicit consent before any personal data is persisted.
+
+## Consent Workflow
+
+1. Clients request or revoke consent through `POST /api/v1/consent/{user_id}`.
+2. The server records the flag and denies vault operations until consent is set.
+3. Users may inspect their current status via `GET /api/v1/consent/{user_id}`.
+
+## Storage Format
+
+Vault entries are stored as JSON objects containing the original payload and
+metadata such as timestamps and plugin identifiers. The entire file is encrypted
+and associated with the user identifier supplied in the API call.
+
+## Key Rotation
+
+Encryption keys are generated per user and kept in the keyring. Administrators
+rotate keys by replacing the stored key material and re‑encrypting existing
+records. During rotation, the service reads each entry with the old key and
+writes it back with the new key without exposing plaintext outside the
+application process.
+
+## Security Implications
+
+- **Limited Access** – vault APIs reject requests without consent, preventing
+  silent data collection.
+- **Encrypted Records** – JSON payloads are encrypted using the user's key to
+  mitigate disk exposure.
+- **Auditing** – all vault operations are logged, allowing operators to review
+  accesses and deletions.
+- **Export & Deletion** – users may export or purge their data, supporting data
+  portability and the right to be forgotten.
+

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -1,0 +1,55 @@
+<!-- Copyright (c) 2024 LibreAssistant contributors. Licensed under the MIT License. -->
+
+# Model Providers
+
+LibreAssistant supports both hosted and local language models through adapter classes.  Each provider can be configured via environment variables and exposes an API endpoint for configuring API keys.  Simple per-minute rate limits guard against accidental overuse.
+
+## CloudProvider
+
+The `CloudProvider` integrates with OpenAI's Chat Completions API.
+
+### Environment Variables
+
+- `OPENAI_MODEL` – model name (default `gpt-3.5-turbo`)
+- `OPENAI_MAX_TOKENS` – maximum tokens to generate
+- `OPENAI_TEMPERATURE` – sampling temperature
+- `OPENAI_RATE_LIMIT` – requests allowed per minute (`0` disables)
+
+### API Key Endpoint
+
+Set the OpenAI API key via the REST API.  Keys are encrypted before storage.
+
+```sh
+POST /api/v1/providers/cloud/key
+{"key": "sk-..."}
+```
+
+### Rate Limiting
+
+The provider tracks request timestamps and raises an error when the limit is exceeded.  Adjust `OPENAI_RATE_LIMIT` to control throttling.
+
+## LocalProvider
+
+The `LocalProvider` sends prompts to a locally hosted model over HTTP (e.g. [Ollama](https://ollama.com/)).
+
+### Environment Variables
+
+- `LOCAL_URL` – endpoint of the local model API
+- `LOCAL_MODEL` – model identifier
+- `LOCAL_MAX_TOKENS` – maximum tokens to generate
+- `LOCAL_TEMPERATURE` – sampling temperature
+- `LOCAL_RATE_LIMIT` – requests allowed per minute (`0` disables)
+
+### API Key Endpoint
+
+Local models typically do not require authentication, but a key can be stored if needed:
+
+```sh
+POST /api/v1/providers/local/key
+{"key": "optional-token"}
+```
+
+### Rate Limiting
+
+Requests are throttled using the same per-minute mechanism as the cloud provider.  Configure the limit with `LOCAL_RATE_LIMIT`.
+

--- a/docs/transparency.md
+++ b/docs/transparency.md
@@ -1,0 +1,49 @@
+<!-- Copyright (c) 2024 LibreAssistant contributors. Licensed under the MIT License. -->
+
+# Transparency Endpoints
+
+LibreAssistant provides endpoints for inspecting runtime behavior and deployed assets.
+
+## `/api/v1/bom`
+
+This endpoint returns a "Bill of Materials" describing the environment in which the
+application is running. The response contains:
+
+- `dependencies` – Python packages discovered via `importlib.metadata`, reported as
+  `name==version` strings. This allows operators to verify the exact library versions
+  loaded at runtime.
+- `models` – files and directories in the models directory referenced by
+  `LA_MODELS_DIR` (default `models/`). Hidden entries are excluded. Each item
+  indicates a model artifact available to the application.
+- `datasets` – files and directories in the datasets directory referenced by
+  `LA_DATASETS_DIR` (default `datasets/`). Hidden entries are excluded. Each item
+  represents a dataset available locally.
+
+Use this endpoint to audit the dependencies and data sources bundled with an
+instance and confirm that expected resources are present.
+
+## `/api/v1/health`
+
+This endpoint reports basic runtime metrics collected by the `HealthMonitor`.
+The response includes:
+
+- `status` – `"ok"` when no errors have been recorded, otherwise `"error"`.
+- `uptime` – number of seconds the process has been running.
+- `requests` – total number of HTTP requests observed since startup.
+- `error_count` – cumulative number of error events.
+- `errors` – up to 100 of the most recent error messages.
+
+Interpreting the status allows administrators to quickly determine if the service
+has encountered errors. Request counts and uptime can be used for basic traffic and
+availability monitoring, while the error list surfaces recent failures.
+
+## HealthMonitor internals
+
+`HealthMonitor` is an in-memory tracker instantiated when the FastAPI application
+is created. Middleware increments the request counter for every inbound request and
+records errors when exceptions occur or responses have a status code of 500 or
+higher. Errors are stored in a fixed-size queue, keeping only the 100 most recent
+messages.
+
+Calling `/api/v1/health` returns a snapshot of these values, allowing operators to
+observe request rates, uptime, and whether any errors have been seen since startup.

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,47 @@
+<!-- Copyright (c) 2024 LibreAssistant contributors. Licensed under the MIT License. -->
+
+# Scripts
+
+Developer utilities for maintaining and building parts of the project.
+
+## `build_theme_catalog.py`
+
+Generates sanitized CSS files and the `theme-catalog.json` index from themes
+in `community-themes`.
+
+Run from the repository root:
+
+```bash
+python scripts/build_theme_catalog.py
+```
+
+The script writes sanitized CSS files into `ui/themes/` and creates
+`ui/theme-catalog.json` with metadata for both built‑in and community themes.
+
+## `check_license_headers.py`
+
+Scans the repository for files missing the standard MIT license header and
+returns a non‑zero exit code if any are found.
+
+Invoke with:
+
+```bash
+python scripts/check_license_headers.py
+# or, since it is executable
+./scripts/check_license_headers.py
+```
+
+## Environment
+
+Both scripts require **Python 3.10+**.
+
+`build_theme_catalog.py` depends on the `libreassistant` package, which in turn
+uses `cssutils` for CSS sanitization. Install project dependencies before
+running the script:
+
+```bash
+pip install -e .
+```
+
+`check_license_headers.py` uses only the Python standard library and has no
+additional dependencies.

--- a/servers/README.md
+++ b/servers/README.md
@@ -1,0 +1,17 @@
+<!-- Copyright (c) 2024 LibreAssistant contributors. Licensed under the MIT License. -->
+
+# MCP Servers
+
+This directory contains sample servers for the [Model Context Protocol](../OVERVIEW.md).
+Each server advertises a set of tools and resources and may require
+environment variables to function.
+
+| Server | Tools | Resources | Environment variables |
+| ------ | ----- | --------- | --------------------- |
+| `echo` | `echo_message` | `echo:last_message` | _None_ |
+| `files` | `fs_read`, `fs_create`, `fs_update`, `fs_delete`, `fs_list` | _None_ | `MCP_FS_BASE_DIR` – root directory for file access |
+| `law_by_keystone` | `generate_legal_summary` | `law:last_summary` | `MCP_FS_BASE_DIR`, `GOVINFO_API_KEY`, `OPENSTATES_API_KEY` |
+| `think_tank` | `analyze_goal` | `thinktank:last_dossier` | `THINK_TANK_MODEL_RESPONSE`, `OPENAI_API_KEY`, `OPENAI_MODEL` |
+
+See the [network policy guide](../docs/network-policy.md) for configuring
+per-server egress restrictions.

--- a/servers/echo/index.ts
+++ b/servers/echo/index.ts
@@ -33,6 +33,14 @@ const prompts: PromptSchema[] = [
   { name: 'echo_template', template: 'Repeat: {{message}}' }
 ];
 
+/**
+ * Invoke the requested tool for the echo server.
+ * Updates internal state when handling `echo_message`.
+ * @param tool   Tool name to execute
+ * @param params Parameters supplied by the client
+ * @returns Result object containing the echoed message
+ * @sideeffect Mutates `lastMessage` with the provided input
+ */
 async function invoke(tool: string, params: any) {
   if (tool === 'echo_message') {
     lastMessage = params?.message ?? '';
@@ -41,6 +49,9 @@ async function invoke(tool: string, params: any) {
   throw new Error(`Unknown tool ${tool}`);
 }
 
+/**
+ * MCP server implementation exposing a single echo tool.
+ */
 const server: MCPServer = {
   listTools: () => tools,
   listResources: () => resources,

--- a/servers/files/index.ts
+++ b/servers/files/index.ts
@@ -68,17 +68,37 @@ const prompts: PromptSchema[] = [
   { name: 'file_edit_template', template: 'Update file {{path}} with new content.' }
 ];
 
+/**
+ * Resolve a user-supplied relative path against the server's base directory.
+ * @param p Relative path from the client
+ * @returns Absolute path within the base directory
+ * @sideeffect Throws if path escapes the allowed directory
+ */
 function resolve(p: string) {
   const full = path.resolve(baseDir, p);
   if (!full.startsWith(baseDir)) throw new Error('path outside allowed directory');
   return full;
 }
 
+/**
+ * Append a file operation to the audit log.
+ * @param user     Optional user identifier
+ * @param action   Performed operation
+ * @param resolved Resolved absolute path
+ * @sideeffect Writes an entry to `file_io_audit.ndjson`
+ */
 async function audit(user: string | undefined, action: string, resolved: string) {
   const entry = { user_id: user, action, path: resolved, timestamp: Date.now() };
   await fs.appendFile(auditLog, JSON.stringify(entry) + '\n');
 }
 
+/**
+ * Invoke a file system tool, performing the requested operation and auditing it.
+ * @param tool   Tool name such as `fs_read` or `fs_update`
+ * @param params Parameters supplied by the client
+ * @returns Result object varying by tool
+ * @sideeffect Reads, writes, or deletes files and appends to audit log
+ */
 async function invoke(tool: string, params: any) {
   const user = params.user_id as string | undefined;
   switch (tool) {
@@ -118,6 +138,9 @@ async function invoke(tool: string, params: any) {
   throw new Error(`Unknown tool ${tool}`);
 }
 
+/**
+ * MCP server exposing basic file system operations.
+ */
 const server: MCPServer = {
   listTools: () => tools,
   listResources: () => resources,

--- a/servers/law_by_keystone/index.ts
+++ b/servers/law_by_keystone/index.ts
@@ -64,20 +64,43 @@ const prompts: PromptSchema[] = [
   },
 ];
 
+/**
+ * Ensure an output directory resides within the allowed base directory.
+ * @param p Desired output path
+ * @returns Resolved absolute path
+ * @sideeffect Throws if path escapes the base directory
+ */
 function ensureDir(p: string) {
   const full = path.resolve(baseDir, p);
   if (!full.startsWith(baseDir)) throw new Error('path outside allowed directory');
   return full;
 }
 
+/**
+ * Escape characters for safe inclusion in XML content.
+ * @param str Raw string
+ * @returns Escaped string
+ */
 function escapeXml(str: string) {
   return str.replace(/[<>&]/g, (c) => ({ '<': '&lt;', '>': '&gt;', '&': '&amp;' }[c]!));
 }
 
+/**
+ * Escape characters for safe inclusion in HTML content.
+ * @param str Raw string
+ * @returns Escaped string
+ */
 function escapeHtml(str: string) {
   return str.replace(/[&<>]/g, (c) => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;' }[c]!));
 }
 
+/**
+ * Fetch legal data from the specified source.
+ * @param source API source identifier
+ * @param query  Query string to search for
+ * @returns Parsed JSON response or error object
+ * @sideeffect Performs network requests to external APIs
+ */
 async function fetchApi(source: Source, query: string) {
   const govinfoKey = process.env.GOVINFO_API_KEY || 'DEMO_KEY';
   const openStatesKey = process.env.OPENSTATES_API_KEY || 'DEMO_KEY';
@@ -111,6 +134,13 @@ async function fetchApi(source: Source, query: string) {
   }
 }
 
+/**
+ * Format fetched legal data into the desired output representation.
+ * @param data   Raw data returned from the API
+ * @param format Output format such as `json`, `html`, or `md`
+ * @param meta   Metadata including query and source
+ * @returns Object containing formatted content and file extension
+ */
 function formatContent(
   data: any,
   format: string,
@@ -156,6 +186,13 @@ function formatContent(
   }
 }
 
+/**
+ * Invoke the `generate_legal_summary` tool to fetch and export legal data.
+ * @param tool   Tool name, only `generate_legal_summary` is supported
+ * @param params Parameters including query, source, and output options
+ * @returns Metadata about the exported summary
+ * @sideeffect Fetches remote data and writes files to disk
+ */
 async function invoke(tool: string, params: any) {
   if (tool !== 'generate_legal_summary')
     throw new Error(`Unknown tool ${tool}`);
@@ -182,6 +219,9 @@ async function invoke(tool: string, params: any) {
   return { status: 'exported', path: filePath, sources: [source], metadata };
 }
 
+/**
+ * MCP server providing legal research capabilities backed by government APIs.
+ */
 const server: MCPServer = {
   listTools: () => tools,
   listResources: () => resources,

--- a/servers/think_tank/index.ts
+++ b/servers/think_tank/index.ts
@@ -9,6 +9,13 @@ import { fileURLToPath } from 'url';
 // variable is unset we attempt to use the OpenAI client.  The call is lazily
 // imported so the dependency is optional.
 
+/**
+ * Call the backing language model to generate structured analysis.
+ * Uses a mock response when `THINK_TANK_MODEL_RESPONSE` is set.
+ * @param prompt Prompt string to send to the model
+ * @returns Parsed JSON response from the model
+ * @sideeffect Performs network requests when no mock is provided
+ */
 async function callModel(prompt: string): Promise<any> {
   const mock = process.env.THINK_TANK_MODEL_RESPONSE;
   if (mock) {
@@ -122,6 +129,13 @@ const prompts: PromptSchema[] = [
   { name: 'thinktank_question_template', template: 'Consider the goal: {{goal}}' }
 ];
 
+/**
+ * Invoke the `analyze_goal` tool to generate a think tank analysis.
+ * @param tool   Tool name, only `analyze_goal` is supported
+ * @param params Parameters containing the goal string
+ * @returns Structured analysis produced by the language model
+ * @sideeffect Calls the language model and updates `lastDossier`
+ */
 async function invoke(tool: string, params: any) {
   if (tool !== 'analyze_goal') throw new Error(`Unknown tool ${tool}`);
   const goal = params.goal;
@@ -144,6 +158,9 @@ Analyze the goal: ${goal}`;
   return result;
 }
 
+/**
+ * MCP server providing structured analysis of user goals.
+ */
 const server: MCPServer = {
   listTools: () => tools,
   listResources: () => resources,

--- a/src/libreassistant/db.py
+++ b/src/libreassistant/db.py
@@ -17,6 +17,19 @@ _conn: sqlite3.Connection | None = None
 
 
 def get_conn() -> sqlite3.Connection:
+    """Return a shared connection to the encrypted database.
+
+    Initializes the database on first use, creating the directory and tables
+    as needed. The connection is cached globally so subsequent calls reuse the
+    same handle.
+
+    Returns:
+        sqlite3.Connection: Active connection to the SQLite database.
+
+    Side Effects:
+        Creates the database file and schema if they do not already exist and
+        sets the global connection.
+    """
     global _conn
     if _conn is None:
         if not DB_KEY:
@@ -29,6 +42,18 @@ def get_conn() -> sqlite3.Connection:
 
 
 def _initialize(conn: sqlite3.Connection) -> None:
+    """Create required tables and indexes in the database.
+
+    Parameters:
+        conn: Connection on which schema creation statements are executed.
+
+    Returns:
+        None.
+
+    Side Effects:
+        Executes SQL statements that create tables and indexes if they do not
+        exist and commits the transaction.
+    """
     cur = conn.cursor()
     cur.execute(
         """
@@ -72,6 +97,17 @@ def clear() -> None:
 
 
 def prune_history() -> None:
+    """Remove stale entries from the history table.
+
+    Deletes rows older than the retention period defined by
+    ``HISTORY_RETENTION_DAYS`` and commits the change.
+
+    Returns:
+        None.
+
+    Side Effects:
+        Modifies the ``history`` table by removing expired records.
+    """
     conn = get_conn()
     cur = conn.cursor()
     cur.execute(
@@ -82,6 +118,17 @@ def prune_history() -> None:
 
 
 def prune_audit() -> None:
+    """Remove stale entries from the file audit table.
+
+    Deletes rows older than the retention period defined by
+    ``AUDIT_RETENTION_DAYS`` and commits the change.
+
+    Returns:
+        None.
+
+    Side Effects:
+        Modifies the ``file_audit`` table by removing expired records.
+    """
     conn = get_conn()
     cur = conn.cursor()
     cur.execute(
@@ -92,6 +139,21 @@ def prune_audit() -> None:
 
 
 def add_history(user_id: str, plugin: str, payload: Dict[str, Any], granted: bool | None) -> None:
+    """Record a plugin invocation for a user.
+
+    Parameters:
+        user_id: Identifier of the user initiating the action.
+        plugin: Name of the plugin invoked.
+        payload: Data passed to the plugin; stored as JSON.
+        granted: Whether consent was granted; ``None`` if unspecified.
+
+    Returns:
+        None.
+
+    Side Effects:
+        Prunes outdated history entries and commits the new record to the
+        database.
+    """
     conn = get_conn()
     prune_history()
     cur = conn.cursor()
@@ -108,6 +170,18 @@ def add_history(user_id: str, plugin: str, payload: Dict[str, Any], granted: boo
 
 
 def get_history(user_id: str) -> List[Dict[str, Any]]:
+    """Retrieve all history entries for a user.
+
+    Parameters:
+        user_id: Identifier of the user whose history is requested.
+
+    Returns:
+        A list of dictionaries containing the plugin name, payload, and
+        optional consent flag.
+
+    Side Effects:
+        None beyond reading from the database.
+    """
     conn = get_conn()
     cur = conn.cursor()
     cur.execute(
@@ -128,6 +202,20 @@ def get_history(user_id: str) -> List[Dict[str, Any]]:
 
 
 def add_file_audit(user_id: str | None, action: str | None, path: str | None) -> None:
+    """Record a file system action in the audit log.
+
+    Parameters:
+        user_id: Identifier of the user performing the action, if known.
+        action: The type of file operation performed.
+        path: The file path involved in the operation.
+
+    Returns:
+        None.
+
+    Side Effects:
+        Prunes outdated audit entries and commits the new record to the
+        database.
+    """
     conn = get_conn()
     prune_audit()
     cur = conn.cursor()
@@ -139,6 +227,18 @@ def add_file_audit(user_id: str | None, action: str | None, path: str | None) ->
 
 
 def get_file_audit(user_id: str | None = None) -> List[Dict[str, Any]]:
+    """Retrieve file audit records, optionally filtering by user.
+
+    Parameters:
+        user_id: If provided, only records for this user are returned.
+
+    Returns:
+        A list of dictionaries with ``user_id``, ``action``, ``path``, and
+        ``timestamp`` keys.
+
+    Side Effects:
+        None beyond reading from the database.
+    """
     conn = get_conn()
     cur = conn.cursor()
     if user_id is None:

--- a/src/libreassistant/mcp_adapter.py
+++ b/src/libreassistant/mcp_adapter.py
@@ -49,6 +49,12 @@ class MCPClient:
         self._queue: queue.Queue[str | None] = queue.Queue()
 
         def _reader() -> None:
+            """Background thread streaming server responses into ``_queue``.
+
+            Lines read from the server's stdout are enqueued for the main
+            thread to process. When the stream ends a ``None`` sentinel is
+            placed on the queue to signal shutdown.
+            """
             if self.proc.stdout is None:
                 raise RuntimeError("MCPClient process has no stdout")
             for line in self.proc.stdout:
@@ -67,6 +73,15 @@ class MCPClient:
         params: Any | None = None,
         timeout: float | None = None,
     ) -> Any:
+        """Send a JSON-RPC request and return the ``result`` field.
+
+        Parameters are encoded in the standard JSON-RPC 2.0 shape containing
+        ``jsonrpc``, ``id`` and ``method`` keys plus an optional ``params``
+        object. A response is awaited for ``timeout`` seconds (defaulting to
+        ``self.timeout``); if no response arrives a :class:`TimeoutError` is
+        raised. The server may report failures by including an ``error`` member
+        in its response, which is surfaced here as ``RuntimeError``.
+        """
         req = {"jsonrpc": "2.0", "id": self.next_id, "method": method}
         self.next_id += 1
         if params is not None:
@@ -94,6 +109,12 @@ class MCPClient:
         return res["result"]
 
     def invoke(self, tool: str, params: Dict[str, Any]) -> Dict[str, Any]:
+        """Invoke a remote tool via JSON-RPC.
+
+        This is a thin wrapper over :meth:`request` that always calls the
+        ``invoke`` method on the MCP server, passing the tool name and
+        arguments as parameters.
+        """
         return self.request("invoke", {"tool": tool, "params": params})
 
     def close(self) -> None:
@@ -134,6 +155,12 @@ class MCPPluginAdapter:
             pass
 
     def _resolve(self, payload: Dict[str, Any]) -> Tuple[str, Dict[str, Any]]:
+        """Map an incoming payload to a tool name and parameters.
+
+        ``resolver`` may be a callable that produces a ``(tool, params)`` pair
+        or a fixed tool name, in which case the raw payload is used as the
+        parameter dictionary.
+        """
         if callable(self.resolver):
             return self.resolver(payload)
         return self.resolver, payload
@@ -141,6 +168,13 @@ class MCPPluginAdapter:
     def run(
         self, user_state: Dict[str, Any], payload: Dict[str, Any]
     ) -> Dict[str, Any]:
+        """Execute the resolved tool against the MCP server.
+
+        The payload is first translated into a target tool and parameter set
+        using :meth:`_resolve`. Invocation errors or resolver failures are
+        caught and returned as ``{"error": <message>}`` dictionaries so that
+        callers receive structured failure information instead of exceptions.
+        """
         try:
             tool, params = self._resolve(payload)
         except Exception as exc:  # pragma: no cover - defensive

--- a/src/mcp/client.ts
+++ b/src/mcp/client.ts
@@ -7,7 +7,10 @@ import path from 'path';
 
 const MAX_LOG_SIZE = 5 * 1024 * 1024; // 5MB
 
-// Wrapper around a remote MCP server accessed via a Transport.
+/**
+ * Wrapper around a remote MCP server accessed via a {@link Transport}.
+ * Caches capability lists and validates parameters before dispatching requests.
+ */
 class RemoteServer implements MCPServer {
   constructor(
     private transport: Transport,
@@ -17,18 +20,36 @@ class RemoteServer implements MCPServer {
     private validators: Map<string, ValidateFunction>
   ) {}
 
+  /**
+   * Return cached tool definitions from the server.
+   * @returns Array of tool schemas
+   */
   listTools() {
     return this.cachedTools;
   }
 
+  /**
+   * Return cached resource definitions from the server.
+   * @returns Array of resource schemas
+   */
   listResources() {
     return this.cachedResources;
   }
 
+  /**
+   * Return cached prompt templates from the server.
+   * @returns Array of prompt schemas
+   */
   listPrompts() {
     return this.cachedPrompts;
   }
 
+  /**
+   * Invoke a remote tool after validating parameters.
+   * @param tool   Tool name to execute
+   * @param params Parameter object to validate and forward
+   * @returns Result from the remote server or validation error object
+   */
   async invoke(tool: string, params: any) {
     const validator = this.validators.get(tool);
     const args = params ?? {};
@@ -39,7 +60,10 @@ class RemoteServer implements MCPServer {
   }
 }
 
-// Client that connects to MCP servers via JSON-RPC transports.
+/**
+ * Client that connects to MCP servers via JSON-RPC transports.
+ * Maintains per-server network policies and an audit log of invocations.
+ */
 export class MCPClient {
   private servers: Map<string, RemoteServer> = new Map();
   private transports: Map<string, Transport> = new Map();
@@ -55,6 +79,13 @@ export class MCPClient {
     MCPClient.patchFetch();
   }
 
+  /**
+   * Register a remote server with the client and cache its capabilities.
+   * @param name      Logical name of the server
+   * @param transport Transport used for communication
+   * @param policy    Optional network policy for requests through this server
+   * @sideeffect Adds the server to internal maps and may start background processes
+   */
   async register(name: string, transport: Transport, policy?: NetworkPolicy) {
     const tools = await transport.request('listTools');
     const resources = await transport.request('listResources');
@@ -71,16 +102,34 @@ export class MCPClient {
     if (policy) this.policies.set(name, policy);
   }
 
+  /**
+   * List the names of all registered servers.
+   * @returns Array of server identifiers
+   */
   listServers() {
     return Array.from(this.servers.keys());
   }
 
+  /**
+   * Retrieve a previously registered server by name.
+   * @param name Server identifier
+   * @returns {@link MCPServer} instance
+   */
   getServer(name: string): MCPServer {
     const server = this.servers.get(name);
     if (!server) throw new Error(`Unknown server ${name}`);
     return server;
   }
 
+  /**
+   * Invoke a tool on a registered server while applying network policies
+   * and recording an audit entry.
+   * @param serverName Server identifier
+   * @param tool       Tool to execute
+   * @param params     Parameters supplied to the tool
+   * @returns Result from the remote invocation
+   * @sideeffect Writes to audit log and may modify files referenced by `params`
+   */
   async invoke(serverName: string, tool: string, params: any) {
     const server = this.getServer(serverName);
     let beforeHash: string | undefined;
@@ -130,6 +179,11 @@ export class MCPClient {
     return result;
   }
 
+  /**
+   * Append an entry to the persistent audit log.
+   * @param entry Audit information to record
+   * @sideeffect Writes to the file system under `logs/`
+   */
   private async appendAudit(entry: AuditEntry) {
     try {
       await fs.mkdir(path.dirname(this.logPath), { recursive: true });
@@ -147,16 +201,29 @@ export class MCPClient {
     }
   }
 
-  close() {
-    for (const transport of this.transports.values()) {
-      transport.close();
-    }
+  /**
+   * Close all registered transports and release their resources.
+   * @sideeffect Terminates network connections or child processes
+   */
+  async close() {
+    await Promise.all(
+      Array.from(this.transports.values(), t => t.close()),
+    );
   }
 
+  /**
+   * Set the default network policy applied when invoking servers without a specific policy.
+   * @param policy Network policy to enforce
+   */
   setDefaultPolicy(policy?: NetworkPolicy) {
     MCPClient.defaultPolicy = policy;
   }
 
+  /**
+   * Patch the global `fetch` function to enforce active network policies.
+   * The patch is applied only once per process.
+   * @sideeffect Overrides the global `fetch`
+   */
   private static patchFetch() {
     if (MCPClient.fetchPatched) return;
     const original = globalThis.fetch.bind(globalThis);

--- a/src/mcp/registry.ts
+++ b/src/mcp/registry.ts
@@ -5,8 +5,13 @@ import fs from 'fs';
 import path from 'path';
 import { fileURLToPath } from 'url';
 
+/**
+ * Shape of the JSON configuration consumed by {@link loadRegistry}.
+ */
 interface RegistryConfig {
+  /** Servers that may be registered */
   servers: { name: string; module: string; network?: NetworkPolicy }[];
+  /** Optional default network policy applied when none specified per server */
   defaultNetwork?: NetworkPolicy;
 }
 
@@ -19,6 +24,8 @@ interface RegistryConfig {
  * @param consentPath Optional path to a JSON file mapping server names to
  *                    boolean consent flags. Defaults to `mcp.consent.json`
  *                    in the same directory as the config file.
+ * @returns Promise that resolves when all allowed servers have been registered
+ * @sideeffect Spawns server processes and updates client state
  */
 export async function loadRegistry(
   configPath: string,

--- a/src/mcp/transport.ts
+++ b/src/mcp/transport.ts
@@ -1,28 +1,57 @@
 import { spawn, ChildProcess } from 'child_process';
 import { MCPServer, NetworkPolicy } from './types.js';
 
-// Basic JSON-RPC message types
+/**
+ * Basic JSON-RPC request message as exchanged over transports.
+ */
 interface JSONRPCRequest {
+  /** Version string, always `"2.0"` */
   jsonrpc: '2.0';
+  /** Sequential identifier for matching responses */
   id: number;
+  /** Method name being invoked */
   method: string;
+  /** Optional parameters for the method */
   params?: any;
 }
 
+/**
+ * Basic JSON-RPC response message as exchanged over transports.
+ */
 interface JSONRPCResponse {
+  /** Version string, always `"2.0"` */
   jsonrpc: '2.0';
+  /** Identifier of the original request */
   id: number;
+  /** Result value when the call succeeds */
   result?: any;
+  /** Error information when the call fails */
   error?: { code: number; message: string; data?: any };
 }
 
-// Transport interface used by the MCP client
+/**
+ * Transport interface used by the MCP client to send JSON-RPC messages.
+ */
 export interface Transport {
+  /**
+   * Send a JSON-RPC request and wait for the response.
+   * @param method Name of the remote method
+   * @param params Optional parameters object
+   * @returns JSON result returned by the server
+   */
   request(method: string, params?: any): Promise<any>;
-  close(): void;
+  /**
+   * Close any underlying resources such as sockets or processes.
+   * Implementations should resolve the returned promise once all handles
+   * have been fully released so tests can reliably await shutdown.
+   */
+  close(): Promise<void>;
 }
 
-// JSON-RPC over child-process stdio
+/**
+ * JSON-RPC transport implemented over a child process's stdio streams.
+ * Spawns a process and proxies JSON-RPC messages to it.
+ */
 export class StdioTransport implements Transport {
   private proc: ChildProcess;
   private nextId = 1;
@@ -32,6 +61,13 @@ export class StdioTransport implements Transport {
   >();
   private buffer = '';
 
+  /**
+   * Create a transport communicating with a child process.
+   * @param command Command to spawn
+   * @param args Arguments to pass to the command
+   * @param policy Network policy passed to the child as environment variables
+   * @sideeffect Spawns a new child process
+   */
   constructor(command: string, args: string[] = [], policy?: NetworkPolicy) {
     this.proc = spawn(command, args, {
       stdio: ['pipe', 'pipe', 'inherit'],
@@ -64,6 +100,12 @@ export class StdioTransport implements Transport {
     });
   }
 
+  /**
+   * Send a JSON-RPC request to the child process.
+   * @param method Remote method name
+   * @param params Optional parameters object
+   * @returns JSON result from the child process
+   */
   request(method: string, params?: any): Promise<any> {
     const id = this.nextId++;
     const req: JSONRPCRequest = { jsonrpc: '2.0', id, method, params };
@@ -73,14 +115,29 @@ export class StdioTransport implements Transport {
     });
   }
 
-  close() {
-    this.proc.kill();
+  /**
+   * Terminate the underlying child process.
+   * @sideeffect Kills the spawned process
+   */
+  async close() {
+    return new Promise<void>(resolve => {
+      this.proc.once('exit', () => resolve());
+      this.proc.kill();
+    });
   }
 }
 
-// JSON-RPC over simple HTTP POST + optional SSE stream
+/**
+ * JSON-RPC transport that communicates with an HTTP endpoint and optional SSE stream.
+ */
 export class HTTPTransport implements Transport {
   private abort?: AbortController;
+  /**
+   * Create an HTTP transport.
+   * @param endpoint URL accepting JSON-RPC POST requests
+   * @param sseEndpoint Optional Server-Sent Events endpoint for notifications
+   * @sideeffect Initiates a long-lived fetch when `sseEndpoint` is provided
+   */
   constructor(private endpoint: string, private sseEndpoint?: string) {
     if (sseEndpoint) {
       this.abort = new AbortController();
@@ -114,6 +171,12 @@ export class HTTPTransport implements Transport {
     }
   }
 
+  /**
+   * Send a JSON-RPC request via HTTP POST.
+   * @param method Remote method name
+   * @param params Optional parameters object
+   * @returns Parsed JSON result from the server
+   */
   async request(method: string, params?: any): Promise<any> {
     const res = await fetch(this.endpoint, {
       method: 'POST',
@@ -125,12 +188,21 @@ export class HTTPTransport implements Transport {
     return json.result;
   }
 
-  close() {
+  /**
+   * Abort any outstanding SSE connection.
+   * @sideeffect Cancels network requests
+   */
+  async close() {
     this.abort?.abort();
+    return Promise.resolve();
   }
 }
 
-// Utility to serve an MCPServer over stdio
+/**
+ * Utility helper to expose an {@link MCPServer} over the current process's stdio.
+ * @param server MCP server implementation to expose
+ * @sideeffect Reads from stdin and writes JSON-RPC responses to stdout
+ */
 export function serveStdio(server: MCPServer) {
   process.stdin.setEncoding('utf8');
   let buffer = '';

--- a/src/mcp/types.ts
+++ b/src/mcp/types.ts
@@ -1,41 +1,98 @@
-// Basic types for Model Context Protocol objects
+/**
+ * Schema describing an executable tool exposed by an MCP server.
+ * Parameters and return values follow JSON Schema definitions.
+ */
 export interface ToolSchema {
+  /** Name of the tool as invoked by clients */
   name: string;
+  /** Human readable description of the tool's behavior */
   description: string;
+  /** JSON Schema describing the expected parameter object */
   parameters: Record<string, unknown>; // JSON Schema
+  /** JSON Schema describing the response object */
   returns: Record<string, unknown>; // JSON Schema
 }
 
+/**
+ * Schema describing a static resource that can be fetched from a server.
+ */
 export interface ResourceSchema {
+  /** URI that uniquely identifies the resource */
   uri: string;
+  /** Human readable description of the resource */
   description: string;
 }
 
+/**
+ * Schema for a prompt template that can be expanded by the client.
+ */
 export interface PromptSchema {
+  /** Identifier of the prompt */
   name: string;
+  /** Template string with handlebars style placeholders */
   template: string;
 }
 
+/**
+ * Interface implemented by all MCP servers.
+ * Each method may perform I/O or network requests depending on the server implementation.
+ */
 export interface MCPServer {
+  /**
+   * List tool definitions available on the server.
+   * @returns Array of {@link ToolSchema} objects
+   */
   listTools(): ToolSchema[];
+  /**
+   * List available resources on the server.
+   * @returns Array of {@link ResourceSchema} objects
+   */
   listResources(): ResourceSchema[];
+  /**
+   * List available prompt templates.
+   * @returns Array of {@link PromptSchema} objects
+   */
   listPrompts(): PromptSchema[];
+  /**
+   * Invoke a tool with a parameter object.
+   * This may trigger arbitrary side effects depending on the tool implementation.
+   * @param tool   Name of the tool to execute
+   * @param params Parameters to pass to the tool
+   * @returns Result value produced by the tool
+   */
   invoke(tool: string, params: any): Promise<any>;
 }
 
+/**
+ * Entry describing a single tool invocation for auditing purposes.
+ */
 export interface AuditEntry {
+  /** Name of the server hosting the tool */
   server: string;
+  /** Invoked tool name */
   tool: string;
+  /** Parameter object supplied by the user */
   params: any;
+  /** Result returned by the server */
   result: any;
+  /** Unix timestamp when the call completed */
   timestamp: number;
+  /** Optional hash of a file before invoking the tool */
   beforeHash?: string;
+  /** Optional hash of a file after invoking the tool */
   afterHash?: string;
+  /** External data sources referenced by the result */
   dataSources?: string[];
 }
 
+/**
+ * Network access policy restricting where servers may make requests.
+ */
 export interface NetworkPolicy {
+  /** Whitelisted hostnames */
   allow?: string[];
+  /** Blacklisted hostnames */
   deny?: string[];
+  /** Allowed protocols such as `https` or `http` */
   protocols?: string[];
 }

--- a/src/switchboard/mcpAdapter.ts
+++ b/src/switchboard/mcpAdapter.ts
@@ -1,8 +1,10 @@
 import { MCPClient } from '../mcp/client.js';
 
-// Adapter that exposes MCP servers as high level "plugins" to the UI.
-// Each plugin maps to a primary tool; the underlying tools/resources/prompts
-// remain hidden from the switchboard.
+/**
+ * Adapter that exposes MCP servers as high level "plugins" to the UI.
+ * Each plugin maps to a primary tool; the underlying tools/resources/prompts
+ * remain hidden from the switchboard.
+ */
 export class MCPAdapter {
   private toolMap: Record<string, string | ((params: any) => string)> = {
     echo: 'echo_message',
@@ -23,10 +25,23 @@ export class MCPAdapter {
 
   constructor(private client: MCPClient) {}
 
+  /**
+   * List available plugin names.
+   * @returns Array of plugin identifiers
+   */
   listPlugins(): string[] {
     return Object.keys(this.toolMap);
   }
 
+  /**
+   * Invoke a plugin by mapping it to the underlying MCP tool.
+   * Prompts for confirmation on destructive file operations and records history.
+   * @param plugin Plugin identifier to execute
+   * @param params Parameters to forward to the underlying tool
+   * @param userId User performing the action
+   * @returns Result from the MCP client
+   * @sideeffect May display consent modal and logs invocation history via HTTP
+   */
   async invokePlugin(plugin: string, params: any, userId: string): Promise<any> {
     const mapping = this.toolMap[plugin];
     if (!mapping) throw new Error(`Unknown plugin ${plugin}`);
@@ -56,6 +71,15 @@ export class MCPAdapter {
     return result;
   }
 
+  /**
+   * Persist an invocation to the user's history log via HTTP.
+   * Failures are ignored so as not to block plugin execution.
+   * @param user    User identifier
+   * @param plugin  Invoked plugin name
+   * @param payload Parameters passed to the plugin
+   * @param granted Whether consent was granted for the action
+   * @sideeffect Performs a network request to `/api/v1/history`
+   */
   private async recordHistory(
     user: string,
     plugin: string,

--- a/ui/README.md
+++ b/ui/README.md
@@ -1,0 +1,61 @@
+# UI Package
+
+This directory contains standalone web components and the assets needed to style them.
+
+```
+ui/
+  components/          # individual custom element modules
+  tokens.css           # shared design tokens and built-in theme variables
+  theme-catalog.json   # metadata for built-in and community themes
+  themes/              # sanitized CSS for each theme listed in the catalog
+```
+
+## Components
+
+Each file in `components/` defines a web component and registers it with
+`customElements.define()`. Components can be loaded on demand by importing their
+module:
+
+```js
+import './components/primary-button.js';
+```
+
+After the import, the `<primary-button>` tag becomes available to the page. This
+pattern keeps bundles small and allows the runtime to lazy‑load components when
+needed.
+
+## Design tokens
+
+`tokens.css` exposes the shared design tokens used across all components. It
+contains typography, spacing and radius scales as well as color variables for
+the built‑in light, dark and high‑contrast themes. The stylesheet should be
+loaded once at application start so every component can reference the tokens.
+
+## Themes
+
+`theme-catalog.json` enumerates the themes that the application can load. The
+JSON entries include an identifier, display name, author and preview color. The
+catalog mixes core themes with community contributions such as the "Solarized"
+example.
+
+Sanitized CSS for each catalog entry lives in `ui/themes/`. Community members
+submit new themes under `community-themes/`, and running
+`scripts/build_theme_catalog.py` updates both the catalog and the compiled CSS in
+`ui/themes/`.
+
+### Registering a custom theme
+
+To add your own theme:
+
+1. Create `community-themes/<your-theme>/metadata.json` and
+   `community-themes/<your-theme>/theme.css` with your variables.
+2. Run `scripts/build_theme_catalog.py` to sanitize the CSS, copy it into
+   `ui/themes/`, and append an entry to `ui/theme-catalog.json`.
+3. Load the new theme in the UI by setting `data-theme="<your-theme>"` on the
+   root element or by injecting the generated CSS.
+
+## Web component loading
+
+The application dynamically loads web component modules as their tags appear in
+the DOM. This ensures the browser only downloads the code required for the
+current view while maintaining compatibility with standard Web Component APIs.


### PR DESCRIPTION
## Summary
- add documentation for personal data vault covering consent workflow, storage format, key rotation, and security implications
- link data-vault guide from API docs and README

## Testing
- `pytest`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a6283e31748332a31080a97564fdb7