### PR TITLE
docs: document MCP module and add TSDoc

### DIFF
--- a/src/mcp/README.md
+++ b/src/mcp/README.md
@@ -1,0 +1,22 @@
+# MCP Module
+
+This directory contains the core pieces for running and connecting to Model Context Protocol (MCP) servers.
+
+## Files
+
+- **client.ts** – Implements `MCPClient`, a client capable of registering multiple remote MCP servers, enforcing network policies, and recording an audit log of tool invocations.
+- **transport.ts** – Provides transport implementations (`StdioTransport`, `HTTPTransport`) and `serveStdio` to expose a server over JSON-RPC.
+- **registry.ts** – Loads MCP servers from a registry configuration file, applying per-server consent and optional network policies.
+- **server-runner.js** – Helper script that launches a server module and serves it over stdio while applying network policy restrictions.
+
+## Generating TypeDoc
+
+TypeDoc can be used to build API documentation from the TSDoc comments:
+
+```bash
+npm install --save-dev typedoc
+npx typedoc --out docs/mcp src/mcp
+```
+
+The generated documentation will appear in `docs/mcp/`.
+

--- a/src/mcp/client.ts
+++ b/src/mcp/client.ts
@@ -7,7 +7,11 @@ import path from 'path';
 
 const MAX_LOG_SIZE = 5 * 1024 * 1024; // 5MB
 
-// Wrapper around a remote MCP server accessed via a Transport.
+/**
+ * Wrapper around a remote MCP server accessed via a {@link Transport}.
+ * Caches introspection data and performs parameter validation before invoking
+ * tools on the remote server.
+ */
 class RemoteServer implements MCPServer {
   constructor(
     private transport: Transport,
@@ -17,18 +21,22 @@ class RemoteServer implements MCPServer {
     private validators: Map<string, ValidateFunction>
   ) {}
 
+  /** Return the list of tools exposed by the server. */
   listTools() {
     return this.cachedTools;
   }
 
+  /** Return the list of resources exposed by the server. */
   listResources() {
     return this.cachedResources;
   }
 
+  /** Return the list of prompts exposed by the server. */
   listPrompts() {
     return this.cachedPrompts;
   }
 
+  /** Invoke a tool on the remote server after validating its parameters. */
   async invoke(tool: string, params: any) {
     const validator = this.validators.get(tool);
     const args = params ?? {};
@@ -39,7 +47,12 @@ class RemoteServer implements MCPServer {
   }
 }
 
-// Client that connects to MCP servers via JSON-RPC transports.
+/**
+ * Client that connects to MCP servers via JSON-RPC transports.
+ *
+ * The client manages multiple remote servers, enforces network policies and
+ * records an audit log of all invocations.
+ */
 export class MCPClient {
   private servers: Map<string, RemoteServer> = new Map();
   private transports: Map<string, Transport> = new Map();
@@ -55,6 +68,13 @@ export class MCPClient {
     MCPClient.patchFetch();
   }
 
+  /**
+   * Register a new remote server with the client.
+   *
+   * @param name      Unique name of the server
+   * @param transport Transport used to communicate with the server
+   * @param policy    Optional network policy for the server
+   */
   async register(name: string, transport: Transport, policy?: NetworkPolicy) {
     const tools = await transport.request('listTools');
     const resources = await transport.request('listResources');
@@ -71,16 +91,25 @@ export class MCPClient {
     if (policy) this.policies.set(name, policy);
   }
 
+  /** Return a list of registered server names. */
   listServers() {
     return Array.from(this.servers.keys());
   }
 
+  /** Retrieve a registered server by name. */
   getServer(name: string): MCPServer {
     const server = this.servers.get(name);
     if (!server) throw new Error(`Unknown server ${name}`);
     return server;
   }
 
+  /**
+   * Invoke a tool on a registered server while recording an audit trail.
+   *
+   * @param serverName Name of the registered server
+   * @param tool       Tool to invoke
+   * @param params     Parameters for the tool
+   */
   async invoke(serverName: string, tool: string, params: any) {
     const server = this.getServer(serverName);
     let beforeHash: string | undefined;
@@ -130,6 +159,7 @@ export class MCPClient {
     return result;
   }
 
+  /** Append an invocation entry to the audit log on disk. */
   private async appendAudit(entry: AuditEntry) {
     try {
       await fs.mkdir(path.dirname(this.logPath), { recursive: true });
@@ -147,16 +177,22 @@ export class MCPClient {
     }
   }
 
+  /** Close all active transports. */
   close() {
     for (const transport of this.transports.values()) {
       transport.close();
     }
   }
 
+  /** Set a default network policy applied to all invocations. */
   setDefaultPolicy(policy?: NetworkPolicy) {
     MCPClient.defaultPolicy = policy;
   }
 
+  /**
+   * Patch the global {@link fetch} function to enforce active network policies.
+   * The patch is applied only once for all client instances.
+   */
   private static patchFetch() {
     if (MCPClient.fetchPatched) return;
     const original = globalThis.fetch.bind(globalThis);

--- a/src/mcp/registry.ts
+++ b/src/mcp/registry.ts
@@ -5,8 +5,14 @@ import fs from 'fs';
 import path from 'path';
 import { fileURLToPath } from 'url';
 
+/**
+ * Shape of the registry configuration file consumed by {@link loadRegistry}.
+ * Each entry describes an MCP server module and its optional network policy.
+ */
 interface RegistryConfig {
+  /** Servers available for registration. */
   servers: { name: string; module: string; network?: NetworkPolicy }[];
+  /** Default network policy applied when a server entry omits one. */
   defaultNetwork?: NetworkPolicy;
 }
 

--- a/src/mcp/server-runner.js
+++ b/src/mcp/server-runner.js
@@ -1,3 +1,8 @@
+/**
+ * Helper script that boots a module exporting an MCP server and exposes it
+ * over stdio using the {@link serveStdio} transport. Network policy restrictions
+ * are enforced based on environment variables before the server is started.
+ */
 import { serveStdio } from './transport.ts';
 import { fileURLToPath, pathToFileURL } from 'url';
 import path from 'path';
@@ -9,6 +14,11 @@ if (!modArg) {
 }
 const modulePath = path.resolve(modArg);
 
+/**
+ * Patch the global {@link fetch} to enforce network policies specified via
+ * environment variables. This mirrors the client's network policy logic when
+ * executing within the server process.
+ */
 function applyPolicy() {
   const allow = (process.env.MCP_ALLOW_HOSTS || '').split(',').filter(Boolean);
   const deny = (process.env.MCP_DENY_HOSTS || '').split(',').filter(Boolean);

--- a/src/mcp/transport.ts
+++ b/src/mcp/transport.ts
@@ -16,13 +16,22 @@ interface JSONRPCResponse {
   error?: { code: number; message: string; data?: any };
 }
 
-// Transport interface used by the MCP client
+/**
+ * Transport interface used by the MCP client.
+ * Implementations are responsible for sending JSON-RPC requests and
+ * returning the corresponding responses.
+ */
 export interface Transport {
+  /** Send a JSON-RPC request. */
   request(method: string, params?: any): Promise<any>;
+  /** Close any underlying resources. */
   close(): void;
 }
 
-// JSON-RPC over child-process stdio
+/**
+ * JSON-RPC transport communicating with a child process over stdio.
+ * Each request is serialized as a newline-delimited JSON object.
+ */
 export class StdioTransport implements Transport {
   private proc: ChildProcess;
   private nextId = 1;
@@ -64,6 +73,7 @@ export class StdioTransport implements Transport {
     });
   }
 
+  /** Send a JSON-RPC request to the child process. */
   request(method: string, params?: any): Promise<any> {
     const id = this.nextId++;
     const req: JSONRPCRequest = { jsonrpc: '2.0', id, method, params };
@@ -73,12 +83,16 @@ export class StdioTransport implements Transport {
     });
   }
 
+  /** Terminate the child process. */
   close() {
     this.proc.kill();
   }
 }
 
-// JSON-RPC over simple HTTP POST + optional SSE stream
+/**
+ * JSON-RPC transport over HTTP POST with an optional Server-Sent Events stream
+ * for receiving notifications.
+ */
 export class HTTPTransport implements Transport {
   private abort?: AbortController;
   constructor(private endpoint: string, private sseEndpoint?: string) {
@@ -114,7 +128,8 @@ export class HTTPTransport implements Transport {
     }
   }
 
-  async request(method: string, params?: any): Promise<any> {
+    /** Send a JSON-RPC request to the HTTP endpoint. */
+    async request(method: string, params?: any): Promise<any> {
     const res = await fetch(this.endpoint, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
@@ -125,13 +140,14 @@ export class HTTPTransport implements Transport {
     return json.result;
   }
 
-  close() {
-    this.abort?.abort();
+    /** Terminate the SSE connection, if any. */
+    close() {
+      this.abort?.abort();
+    }
   }
-}
 
-// Utility to serve an MCPServer over stdio
-export function serveStdio(server: MCPServer) {
+  /** Utility to serve an {@link MCPServer} over stdio. */
+  export function serveStdio(server: MCPServer) {
   process.stdin.setEncoding('utf8');
   let buffer = '';
   process.stdin.on('data', chunk => {


### PR DESCRIPTION
## Summary
- document MCP client, transport, and registry utilities
- add JSDoc comments to core classes and server runner
- describe how to generate TypeDoc documentation

## Testing
- `npm test`
- `npx -y typedoc --out /tmp/mcp-docs src/mcp` *(fails: entry point not referenced)*

------
https://chatgpt.com/codex/tasks/task_e_68a6286c68288332a8f407510445d6de