### PR TITLE
docs: add provider configuration guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,9 @@ LibreAssistant ships with adapters for both hosted and local models.  The
 following environment variables control defaults and simple per-minute rate
 limits.  A value of `0` disables throttling.
 
+Additional configuration details and API key endpoints are documented in
+[docs/providers.md](docs/providers.md).
+
 | Provider | Variables |
 | --- | --- |
 | OpenAI | `OPENAI_MODEL`, `OPENAI_MAX_TOKENS`, `OPENAI_TEMPERATURE`, `OPENAI_RATE_LIMIT` |

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -1,0 +1,55 @@
+<!-- Copyright (c) 2024 LibreAssistant contributors. Licensed under the MIT License. -->
+
+# Model Providers
+
+LibreAssistant supports both hosted and local language models through adapter classes.  Each provider can be configured via environment variables and exposes an API endpoint for configuring API keys.  Simple per-minute rate limits guard against accidental overuse.
+
+## CloudProvider
+
+The `CloudProvider` integrates with OpenAI's Chat Completions API.
+
+### Environment Variables
+
+- `OPENAI_MODEL` – model name (default `gpt-3.5-turbo`)
+- `OPENAI_MAX_TOKENS` – maximum tokens to generate
+- `OPENAI_TEMPERATURE` – sampling temperature
+- `OPENAI_RATE_LIMIT` – requests allowed per minute (`0` disables)
+
+### API Key Endpoint
+
+Set the OpenAI API key via the REST API.  Keys are encrypted before storage.
+
+```sh
+POST /api/v1/providers/cloud/key
+{"key": "sk-..."}
+```
+
+### Rate Limiting
+
+The provider tracks request timestamps and raises an error when the limit is exceeded.  Adjust `OPENAI_RATE_LIMIT` to control throttling.
+
+## LocalProvider
+
+The `LocalProvider` sends prompts to a locally hosted model over HTTP (e.g. [Ollama](https://ollama.com/)).
+
+### Environment Variables
+
+- `LOCAL_URL` – endpoint of the local model API
+- `LOCAL_MODEL` – model identifier
+- `LOCAL_MAX_TOKENS` – maximum tokens to generate
+- `LOCAL_TEMPERATURE` – sampling temperature
+- `LOCAL_RATE_LIMIT` – requests allowed per minute (`0` disables)
+
+### API Key Endpoint
+
+Local models typically do not require authentication, but a key can be stored if needed:
+
+```sh
+POST /api/v1/providers/local/key
+{"key": "optional-token"}
+```
+
+### Rate Limiting
+
+Requests are throttled using the same per-minute mechanism as the cloud provider.  Configure the limit with `LOCAL_RATE_LIMIT`.
+


### PR DESCRIPTION
## Summary
- document CloudProvider and LocalProvider configuration and endpoints
- link README model provider section to detailed docs

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'pysqlcipher3')*
- `npm test` *(hangs; emits experimental loader warnings without completing)*

------
https://chatgpt.com/codex/tasks/task_e_68a62871d6648332a9e6aa7730574041