### PR TITLE
docs: document MCP module and add jsdoc

### DIFF
--- a/src/mcp/README.md
+++ b/src/mcp/README.md
@@ -1,0 +1,36 @@
+# MCP subsystem
+
+This directory contains a minimal implementation of components that speak the Model Context Protocol (MCP).
+
+## Files
+
+### client.ts
+Wraps remote MCP servers and exposes a high level `MCPClient` class. The client caches server capabilities, enforces network policies, and records an audit log of tool invocations.
+
+### transport.ts
+Defines the `Transport` interface along with implementations:
+`StdioTransport` for child processes, `HTTPTransport` for HTTP endpoints, and the `serveStdio` helper that exposes a server over stdio.
+
+### registry.ts
+Loads a JSON registry configuration and registers servers with an `MCPClient` when consent is granted. Optional network policies are applied per server or as defaults.
+
+### server-runner.js
+Helper script used by the registry to spawn a server module in its own process. It applies network policy restrictions and exposes the module via stdio using `serveStdio`.
+
+## Generating TypeDoc
+
+TypeDoc can generate HTML API documentation from the TypeScript sources.
+
+1. Install TypeDoc:
+
+   ```bash
+   npm install --save-dev typedoc
+   ```
+
+2. Generate documentation for the MCP module:
+
+   ```bash
+   npx typedoc src/mcp --out docs/mcp
+   ```
+
+The generated files will appear under `docs/mcp`.

--- a/src/mcp/client.ts
+++ b/src/mcp/client.ts
@@ -12,6 +12,14 @@ const MAX_LOG_SIZE = 5 * 1024 * 1024; // 5MB
  * Caches capability lists and validates parameters before dispatching requests.
  */
 class RemoteServer implements MCPServer {
+  /**
+   * Create a wrapper around a remote MCP server.
+   * @param transport       Underlying transport used for JSON-RPC communication
+   * @param cachedTools     Tool capability list retrieved during registration
+   * @param cachedResources Resource capability list retrieved during registration
+   * @param cachedPrompts   Prompt templates available on the server
+   * @param validators      Precompiled AJV validators keyed by tool name
+   */
   constructor(
     private transport: Transport,
     private cachedTools: any[],
@@ -75,6 +83,11 @@ export class MCPClient {
   private static fetchPatched = false;
   private logPath = path.resolve('logs/audit.ndjson');
 
+  /**
+   * Create a new client instance.
+   * The constructor ensures the global `fetch` is patched once so that
+   * network policies can be enforced by {@link MCPClient}.
+   */
   constructor() {
     MCPClient.patchFetch();
   }

--- a/src/mcp/server-runner.js
+++ b/src/mcp/server-runner.js
@@ -1,3 +1,8 @@
+/**
+ * Bootstraps an MCP server module and exposes it over stdio. This script is
+ * used by the registry to spawn servers in isolated processes while enforcing
+ * network policies.
+ */
 import { serveStdio } from './transport.ts';
 import { fileURLToPath, pathToFileURL } from 'url';
 import path from 'path';
@@ -9,6 +14,11 @@ if (!modArg) {
 }
 const modulePath = path.resolve(modArg);
 
+/**
+ * Apply network policy restrictions from environment variables to the global
+ * `fetch` implementation. Hosts and protocols not explicitly allowed will
+ * cause requests to be rejected.
+ */
 function applyPolicy() {
   const allow = (process.env.MCP_ALLOW_HOSTS || '').split(',').filter(Boolean);
   const deny = (process.env.MCP_DENY_HOSTS || '').split(',').filter(Boolean);


### PR DESCRIPTION
## Summary
- document MCP helper modules and add instructions for generating TypeDoc
- add missing JSDoc comments for constructors and server runner utilities

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a645cbb3948332a376b2a1f0fd4fbd