### PR TITLE
docs: add plugin reference pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,7 @@ use the built‑in tools.
 
 - **Chat with models you trust** – point LibreAssistant at local or cloud
   providers and inspect every request.
-- **Do more with plugins** – read and write files, analyse goals, or integrate
-  your own tools.
+- **Do more with plugins** – read and write files, analyse goals, or integrate your own tools. Built-in plugins include [Echo](docs/echo_plugin.md), [File I/O](docs/file_io_plugin.md), and [Think Tank](docs/think_tank_plugin.md).
 - **Transparent by design** – dashboards reveal system health and every
   component that participates in a request.
 - **Fine-grained network control** – configure per-server allow/deny lists and

--- a/docs/echo_plugin.md
+++ b/docs/echo_plugin.md
@@ -1,0 +1,31 @@
+<!-- Copyright (c) 2024 LibreAssistant contributors. Licensed under the MIT License. -->
+
+# Echo Plugin
+
+The `echo` plugin returns a supplied message and records it in the user's state. It serves as a minimal reference implementation for building new plugins.
+
+## Input Schema
+
+```python
+from pydantic import BaseModel
+
+class EchoInput(BaseModel):
+    message: str = ""
+```
+
+## Example
+
+```bash
+curl -X POST http://localhost:8000/api/v1/invoke \
+  -H "Content-Type: application/json" \
+  -d '{
+        "plugin": "echo",
+        "user_id": "alice",
+        "payload": {"message": "hi"}
+      }'
+```
+
+## Security Considerations
+
+- The plugin stores the last echoed message in `user_state["last_message"]` and the per-user history. Avoid echoing sensitive information that should not persist.
+- No external network or filesystem access is performed.

--- a/docs/file_io_plugin.md
+++ b/docs/file_io_plugin.md
@@ -1,0 +1,62 @@
+<!-- Copyright (c) 2024 LibreAssistant contributors. Licensed under the MIT License. -->
+
+# File I/O Plugin
+
+The `file_io` plugin exposes basic filesystem operations through an MCP server. It allows reading, creating, updating, deleting, and listing files within a restricted directory.
+
+## Input Schema
+
+```python
+from typing import Literal
+from pydantic import BaseModel, model_validator
+
+class FileIOInput(BaseModel):
+    operation: Literal["read", "create", "update", "delete", "list"]
+    path: str
+    content: str | None = None
+    confirm: bool | None = None
+
+    @model_validator(mode="after")
+    def _check_requirements(self):
+        if self.operation in {"create", "update"} and self.content is None:
+            raise ValueError("content required")
+        if self.operation in {"update", "delete"} and not self.confirm:
+            raise ValueError("confirm required")
+        return self
+```
+
+## Examples
+
+Create a new file:
+
+```bash
+curl -X POST http://localhost:8000/api/v1/invoke \
+  -H "Content-Type: application/json" \
+  -d '{
+        "plugin": "file_io",
+        "user_id": "alice",
+        "payload": {
+          "operation": "create",
+          "path": "~/desktop/note.txt",
+          "content": "hello"
+        }
+      }'
+```
+
+List files in a directory:
+
+```bash
+curl -X POST http://localhost:8000/api/v1/invoke \
+  -H "Content-Type: application/json" \
+  -d '{
+        "plugin": "file_io",
+        "user_id": "alice",
+        "payload": {"operation": "list", "path": "~/desktop"}
+      }'
+```
+
+## Security Considerations
+
+- Access is limited to the `~/desktop` directory via `ALLOWED_BASE_DIR` and validated with `os.path.realpath` to prevent path traversal.
+- Destructive operations (`update`, `delete`) require an explicit `confirm` flag.
+- Each operation is logged with `db.add_file_audit` for accountability.

--- a/docs/plugin-api.md
+++ b/docs/plugin-api.md
@@ -4,6 +4,12 @@
 
 Plugins extend LibreAssistant by implementing custom behavior that can be invoked through the microkernel.
 
+Documentation for built-in plugins:
+
+- [Echo](echo_plugin.md)
+- [File I/O](file_io_plugin.md)
+- [Think Tank](think_tank_plugin.md)
+
 ## Plugin Interface
 
 A plugin is any object that provides a `run` method with the following signature:

--- a/docs/think_tank_plugin.md
+++ b/docs/think_tank_plugin.md
@@ -1,0 +1,31 @@
+<!-- Copyright (c) 2024 LibreAssistant contributors. Licensed under the MIT License. -->
+
+# Think Tank Plugin
+
+The `think_tank` plugin coordinates a collection of specialist agents through an MCP server to analyse a high-level goal and return an aggregated analysis. Each result is appended to a per-user dossier.
+
+## Input Schema
+
+```python
+from pydantic import BaseModel
+
+class ThinkTankInput(BaseModel):
+    goal: str
+```
+
+## Example
+
+```bash
+curl -X POST http://localhost:8000/api/v1/invoke \
+  -H "Content-Type: application/json" \
+  -d '{
+        "plugin": "think_tank",
+        "user_id": "alice",
+        "payload": {"goal": "Improve education"}
+      }'
+```
+
+## Security Considerations
+
+- Analyses are stored in `user_state["thinktank_dossier"]`; avoid submitting goals containing confidential information.
+- The plugin interacts only with internal experts and does not read or write files or contact external networks by default.


### PR DESCRIPTION
## Summary
- document echo, file I/O, and think tank plugins
- link plugin docs from README and plugin API

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'pysqlcipher3')*

------
https://chatgpt.com/codex/tasks/task_e_68a64713ea208332ab38ea0440fc57f7