### PR TITLE
docs: add core module readme

### DIFF
--- a/src/libreassistant/README.md
+++ b/src/libreassistant/README.md
@@ -1,0 +1,32 @@
+# LibreAssistant Core
+
+This package contains the runtime pieces that power the LibreAssistant API server.
+
+## Kernel
+
+The [kernel](./kernel.py) implements a tiny microkernel that keeps per-user state and routes
+requests to registered plugins.
+
+## Plugins
+
+Built-in plugins live in the [plugins](./plugins/) directory.  Each plugin exposes a
+`register()` helper that adds the plugin to the kernel during start-up.
+
+## Providers
+
+Language model backends are wrapped by the [providers](./providers/) registry.  The
+`ProviderManager` securely stores API keys and dispatches prompts to either local or cloud
+implementations.
+
+## Entrypoints
+
+- [main.py](./main.py) builds the FastAPI application, registers default plugins and providers,
+  and exposes REST endpoints.
+- [__main__.py](./__main__.py) runs the application with Uvicorn for local development.
+
+## Additional Resources
+
+- [Documentation](../../docs/)
+- [Experts](./experts/)
+- [Plugins](./plugins/)
+- [Providers](./providers/)


### PR DESCRIPTION
## Summary
- document LibreAssistant core runtime with an overview README
- describe microkernel responsibilities, plugin registration, provider registry, and entry points
- link to plugin, provider, docs, and expert directories for further reading

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'pysqlcipher3')*


------
https://chatgpt.com/codex/tasks/task_e_68a64b0e497083328950126c7cdd7b57