### PR TITLE
docs: add experts overview

### DIFF
--- a/src/libreassistant/experts/README.md
+++ b/src/libreassistant/experts/README.md
@@ -1,0 +1,31 @@
+<!-- Copyright (c) 2024 LibreAssistant contributors. Licensed under the MIT License. -->
+
+# Experts
+
+LibreAssistant relies on a group of specialist "experts" that each analyze a goal from a different angle. Their independent outputs are later combined to provide a balanced response.
+
+## Available experts
+
+- **aggregation** – condenses the analyses from other experts into a concise summary.
+- **argumentation** – supplies persuasive points supporting the goal.
+- **communications** – crafts a public-facing message and identifies the target audience.
+- **devils_advocate** – highlights potential risks or unintended consequences.
+- **executive** – breaks the goal into an ordered list of actionable tasks.
+- **research** – offers a brief research digest with at least one source.
+- **visualizer** – proposes simple chart metadata to illustrate progress.
+
+Each expert runs independently. Their results can be collected in a dictionary and passed to `aggregation.summarize` to produce a final report.
+
+## Example
+
+```python
+from libreassistant.experts import argumentation, communications, aggregation
+
+goal = "build a community garden"
+analysis = {
+    "communications": communications.analyze(goal),
+    "argumentation": argumentation.analyze(goal),
+}
+summary = aggregation.summarize(analysis)
+print(summary)
+```


### PR DESCRIPTION
## Summary
- document the purpose of aggregation, argumentation, communications, and other experts
- explain how expert analyses are combined via `aggregation.summarize`
- provide a Python example for invoking expert functions

## Testing
- `python scripts/check_license_headers.py src/libreassistant/experts/README.md` *(fails: Missing MIT license header in: ARCHITECTURE.md, PLUGIN-CONVERSIONS.md, OVERVIEW.md, UI-SPEC-MCP.md, SECURITY.md, MIGRATION.md, ui/README.md, tests/README.md, tests/test_mcp_consent.py, tests/test_db_encryption.py, tests/test_history_record.py, tests/test_mcp_adapter.py, tests/test_think_tank_plugin.py, tests/test_law_by_keystone_plugin.py, tests/test_file_io_plugin.py, tests/test_file_audit.py, logs/README.md, docs/law_api.md, node_modules/typescript/README.md, node_modules/typescript/ThirdPartyNoticeText.txt, node_modules/typescript/SECURITY.md, node_modules/undici-types/README.md, node_modules/v8-compile-cache-lib/README.md, node_modules/v8-compile-cache-lib/CHANGELOG.md, node_modules/fast-deep-equal/README.md, node_modules/diff/README.md, node_modules/diff/CONTRIBUTING.md, node_modules/diff/release-notes.md, node_modules/acorn-walk/README.md, node_modules/acorn-walk/CHANGELOG.md, node_modules/json-schema-traverse/README.md, node_modules/json-schema-traverse/.eslintrc.yml, node_modules/ts-node/README.md, node_modules/arg/README.md, node_modules/arg/LICENSE.md, node_modules/create-require/README.md, node_modules/create-require/CHANGELOG.md, node_modules/require-from-string/readme.md, node_modules/make-error/README.md, node_modules/yn/readme.md, node_modules/acorn/README.md, node_modules/acorn/CHANGELOG.md, node_modules/ajv/README.md, node_modules/fast-uri/README.md, node_modules/@types/node/README.md, node_modules/@cspotcode/source-map-support/README.md, node_modules/@cspotcode/source-map-support/LICENSE.md, node_modules/json-schema-traverse/.github/FUNDING.yml, node_modules/json-schema-traverse/spec/.eslintrc.yml, node_modules/json-schema-traverse/.github/workflows/build.yml, node_modules/json-schema-traverse/.github/workflows/publish.yml, node_modules/ts-node/dist-raw/README.md, node_modules/ts-node/dist-raw/NODE-LICENSE.md, node_modules/@tsconfig/node14/README.md, node_modules/@tsconfig/node10/README.md, node_modules/@tsconfig/node12/README.md, node_modules/@tsconfig/node16/README.md, node_modules/fast-uri/.github/.stale.yml, node_modules/fast-uri/.github/dependabot.yml, node_modules/fast-uri/.github/tests_checker.yml, node_modules/fast-uri/.github/workflows/package-manager-ci.yml, node_modules/fast-uri/.github/workflows/ci.yml, node_modules/@jridgewell/resolve-uri/README.md, node_modules/@jridgewell/trace-mapping/README.md, node_modules/@jridgewell/sourcemap-codec/README.md, .venv/bin/activate_this.py, .venv/lib/python3.12/site-packages/_virtualenv.py, src/libreassistant/README.md, src/libreassistant/mcp_adapter.py, src/libreassistant/db.py, src/mcp/README.md, src/libreassistant/experts/aggregation.py, src/libreassistant/experts/devils_advocate.py, src/libreassistant/experts/research.py, src/libreassistant/experts/__init__.py, src/libreassistant/experts/communications.py, src/libreassistant/experts/executive.py, src/libreassistant/experts/argumentation.py, src/libreassistant/experts/visualizer.py)
- `python -m pytest` *(fails: ModuleNotFoundError: No module named 'fastapi')*
- `npx --yes markdownlint-cli src/libreassistant/experts/README.md`
- `npm test` *(terminated: long runtime)*

------
https://chatgpt.com/codex/tasks/task_e_68a64c4e78d88332b17e88f786002c56