### PR TITLE
chore: add license headers

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,3 +1,5 @@
+<!-- Copyright (c) 2024 LibreAssistant contributors. Licensed under the MIT License. -->
+
 # Architecture Review
 
 ## Current Flow

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,3 +1,5 @@
+<!-- Copyright (c) 2024 LibreAssistant contributors. Licensed under the MIT License. -->
+
 # MCP Migration Plan
 
 ## Phase 1 – Client & Registry

--- a/OVERVIEW.md
+++ b/OVERVIEW.md
@@ -1,3 +1,5 @@
+<!-- Copyright (c) 2024 LibreAssistant contributors. Licensed under the MIT License. -->
+
 # Model Context Protocol Overview
 
 Model Context Protocol (MCP) defines a neutral interface between AI clients and external capability providers. It addresses the classic N×M integration problem by standardising how models discover and use tools, resources and prompts.

--- a/PLUGIN-CONVERSIONS.md
+++ b/PLUGIN-CONVERSIONS.md
@@ -1,3 +1,5 @@
+<!-- Copyright (c) 2024 LibreAssistant contributors. Licensed under the MIT License. -->
+
 # Plugin Conversion Notes
 
 ## Echo Plugin → MCP

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,3 +1,5 @@
+<!-- Copyright (c) 2024 LibreAssistant contributors. Licensed under the MIT License. -->
+
 # Security Notes
 
 ## Consent Model

--- a/UI-SPEC-MCP.md
+++ b/UI-SPEC-MCP.md
@@ -1,3 +1,5 @@
+<!-- Copyright (c) 2024 LibreAssistant contributors. Licensed under the MIT License. -->
+
 # MCP Server Manager UI
 
 The switchboard lists discovered servers in a side panel. Each entry expands to show available tools, resources and prompts. Dangerous tools display a confirmation modal before execution. The history view includes JSON‑formatted audit entries for every call.

--- a/docs/law_api.md
+++ b/docs/law_api.md
@@ -1,3 +1,5 @@
+<!-- Copyright (c) 2024 LibreAssistant contributors. Licensed under the MIT License. -->
+
 # Law Plugin
 
 The `law_by_keystone` MCP server queries public government APIs to gather legal

--- a/logs/README.md
+++ b/logs/README.md
@@ -1,3 +1,5 @@
+<!-- Copyright (c) 2024 LibreAssistant contributors. Licensed under the MIT License. -->
+
 # Audit logs
 
 This directory stores runtime audit logs in newline-delimited JSON (NDJSON) format.

--- a/scripts/check_license_headers.py
+++ b/scripts/check_license_headers.py
@@ -25,7 +25,14 @@ def main() -> None:
     repo = pathlib.Path(__file__).resolve().parent.parent
     failures: list[str] = []
     for path in repo.rglob("*"):
-        if path.is_file() and ".git" not in path.parts and ".pytest_cache" not in path.parts and path.name != "LICENSE.txt":
+        if (
+            path.is_file()
+            and ".git" not in path.parts
+            and ".pytest_cache" not in path.parts
+            and "node_modules" not in path.parts
+            and ".venv" not in path.parts
+            and path.name != "LICENSE.txt"
+        ):
             if path.suffix in {".md", ".py", ".yml", ".yaml", ".sh", ".txt"}:
                 if not file_has_header(path):
                     failures.append(str(path.relative_to(repo)))

--- a/servers/echo/index.ts
+++ b/servers/echo/index.ts
@@ -1,3 +1,6 @@
+// Copyright (c) 2024 LibreAssistant contributors.
+// Licensed under the MIT License.
+
 import { MCPServer, ToolSchema, ResourceSchema, PromptSchema } from '../../src/mcp/types.js';
 import { serveStdio } from '../../src/mcp/transport.js';
 import { fileURLToPath } from 'url';

--- a/servers/files/index.ts
+++ b/servers/files/index.ts
@@ -1,3 +1,6 @@
+// Copyright (c) 2024 LibreAssistant contributors.
+// Licensed under the MIT License.
+
 import { promises as fs } from 'fs';
 import path from 'path';
 import { MCPServer, ToolSchema, ResourceSchema, PromptSchema } from '../../src/mcp/types.js';

--- a/servers/law_by_keystone/index.ts
+++ b/servers/law_by_keystone/index.ts
@@ -1,3 +1,6 @@
+// Copyright (c) 2024 LibreAssistant contributors.
+// Licensed under the MIT License.
+
 import { promises as fs } from 'fs';
 import path from 'path';
 import {

--- a/servers/think_tank/index.ts
+++ b/servers/think_tank/index.ts
@@ -1,3 +1,6 @@
+// Copyright (c) 2024 LibreAssistant contributors.
+// Licensed under the MIT License.
+
 import { MCPServer, ToolSchema, ResourceSchema, PromptSchema } from '../../src/mcp/types.js';
 import { serveStdio } from '../../src/mcp/transport.js';
 import { fileURLToPath } from 'url';

--- a/src/libreassistant/README.md
+++ b/src/libreassistant/README.md
@@ -1,3 +1,5 @@
+<!-- Copyright (c) 2024 LibreAssistant contributors. Licensed under the MIT License. -->
+
 # LibreAssistant Core
 
 This package contains the runtime pieces that power the LibreAssistant API server.

--- a/src/libreassistant/db.py
+++ b/src/libreassistant/db.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2024 LibreAssistant contributors.
+# Licensed under the MIT License.
+
 """Lightweight SQLite database for history and audit logs."""
 
 from __future__ import annotations

--- a/src/libreassistant/experts/__init__.py
+++ b/src/libreassistant/experts/__init__.py
@@ -1,1 +1,4 @@
+# Copyright (c) 2024 LibreAssistant contributors.
+# Licensed under the MIT License.
+
 """Specialist expert modules providing analysis for ThinkTank."""

--- a/src/libreassistant/experts/aggregation.py
+++ b/src/libreassistant/experts/aggregation.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2024 LibreAssistant contributors.
+# Licensed under the MIT License.
+
 """Aggregate expert analyses into a final summary via a language model."""
 
 from __future__ import annotations

--- a/src/libreassistant/experts/argumentation.py
+++ b/src/libreassistant/experts/argumentation.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2024 LibreAssistant contributors.
+# Licensed under the MIT License.
+
 """Argumentation analysis module driven by a language model."""
 
 from __future__ import annotations

--- a/src/libreassistant/experts/communications.py
+++ b/src/libreassistant/experts/communications.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2024 LibreAssistant contributors.
+# Licensed under the MIT License.
+
 """Communications analysis module using a language model."""
 
 from __future__ import annotations

--- a/src/libreassistant/experts/devils_advocate.py
+++ b/src/libreassistant/experts/devils_advocate.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2024 LibreAssistant contributors.
+# Licensed under the MIT License.
+
 """Devil's advocate analysis module using a model call."""
 
 from __future__ import annotations

--- a/src/libreassistant/experts/executive.py
+++ b/src/libreassistant/experts/executive.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2024 LibreAssistant contributors.
+# Licensed under the MIT License.
+
 """Executive analysis module backed by a language model."""
 
 from __future__ import annotations

--- a/src/libreassistant/experts/research.py
+++ b/src/libreassistant/experts/research.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2024 LibreAssistant contributors.
+# Licensed under the MIT License.
+
 """Research analysis module powered by a language model."""
 
 from __future__ import annotations

--- a/src/libreassistant/experts/visualizer.py
+++ b/src/libreassistant/experts/visualizer.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2024 LibreAssistant contributors.
+# Licensed under the MIT License.
+
 """Visualization analysis module powered by a model."""
 
 from __future__ import annotations

--- a/src/libreassistant/mcp_adapter.py
+++ b/src/libreassistant/mcp_adapter.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2024 LibreAssistant contributors.
+# Licensed under the MIT License.
+
 """Adapters allowing MCP servers to appear as legacy Plugin objects."""
 from __future__ import annotations
 

--- a/src/mcp/README.md
+++ b/src/mcp/README.md
@@ -1,3 +1,5 @@
+<!-- Copyright (c) 2024 LibreAssistant contributors. Licensed under the MIT License. -->
+
 # MCP subsystem
 
 This directory contains a minimal implementation of components that speak the Model Context Protocol (MCP).

--- a/src/mcp/client.ts
+++ b/src/mcp/client.ts
@@ -1,3 +1,6 @@
+// Copyright (c) 2024 LibreAssistant contributors.
+// Licensed under the MIT License.
+
 import { createHash } from 'crypto';
 import Ajv, { ValidateFunction } from 'ajv';
 import { MCPServer, AuditEntry, NetworkPolicy } from './types.js';

--- a/src/mcp/registry.ts
+++ b/src/mcp/registry.ts
@@ -1,3 +1,6 @@
+// Copyright (c) 2024 LibreAssistant contributors.
+// Licensed under the MIT License.
+
 import { MCPClient } from './client.js';
 import { StdioTransport } from './transport.js';
 import { NetworkPolicy } from './types.js';

--- a/src/mcp/server-runner.js
+++ b/src/mcp/server-runner.js
@@ -1,3 +1,6 @@
+// Copyright (c) 2024 LibreAssistant contributors.
+// Licensed under the MIT License.
+
 /**
  * Bootstraps an MCP server module and exposes it over stdio. This script is
  * used by the registry to spawn servers in isolated processes while enforcing

--- a/src/mcp/transport.ts
+++ b/src/mcp/transport.ts
@@ -1,3 +1,6 @@
+// Copyright (c) 2024 LibreAssistant contributors.
+// Licensed under the MIT License.
+
 import { spawn, ChildProcess } from 'child_process';
 import { MCPServer, NetworkPolicy } from './types.js';
 

--- a/src/mcp/types.ts
+++ b/src/mcp/types.ts
@@ -1,3 +1,6 @@
+// Copyright (c) 2024 LibreAssistant contributors.
+// Licensed under the MIT License.
+
 /**
  * Schema describing an executable tool exposed by an MCP server.
  * Parameters and return values follow JSON Schema definitions.

--- a/src/switchboard/mcpAdapter.ts
+++ b/src/switchboard/mcpAdapter.ts
@@ -1,3 +1,6 @@
+// Copyright (c) 2024 LibreAssistant contributors.
+// Licensed under the MIT License.
+
 /**
  * Switchboard adapter that exposes MCP servers as high level "plugins".
  *

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,3 +1,5 @@
+<!-- Copyright (c) 2024 LibreAssistant contributors. Licensed under the MIT License. -->
+
 # Tests
 
 This directory contains the test suite for LibreAssistant.

--- a/tests/test_db_encryption.py
+++ b/tests/test_db_encryption.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2024 LibreAssistant contributors.
+# Licensed under the MIT License.
+
 import importlib
 
 from libreassistant import db as app_db

--- a/tests/test_file_audit.py
+++ b/tests/test_file_audit.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2024 LibreAssistant contributors.
+# Licensed under the MIT License.
+
 from pathlib import Path
 
 from libreassistant.plugins import file_io

--- a/tests/test_file_io_plugin.py
+++ b/tests/test_file_io_plugin.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2024 LibreAssistant contributors.
+# Licensed under the MIT License.
+
 from __future__ import annotations
 
 from pathlib import Path

--- a/tests/test_history_record.py
+++ b/tests/test_history_record.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2024 LibreAssistant contributors.
+# Licensed under the MIT License.
+
 """Tests for recording history entries explicitly."""
 
 

--- a/tests/test_law_by_keystone_plugin.py
+++ b/tests/test_law_by_keystone_plugin.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2024 LibreAssistant contributors.
+# Licensed under the MIT License.
+
 import json
 import shutil
 from pathlib import Path

--- a/tests/test_mcp_adapter.py
+++ b/tests/test_mcp_adapter.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2024 LibreAssistant contributors.
+# Licensed under the MIT License.
+
 import subprocess
 import sys
 import textwrap

--- a/tests/test_mcp_consent.py
+++ b/tests/test_mcp_consent.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2024 LibreAssistant contributors.
+# Licensed under the MIT License.
+
 from fastapi.testclient import TestClient
 
 

--- a/tests/test_think_tank_plugin.py
+++ b/tests/test_think_tank_plugin.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2024 LibreAssistant contributors.
+# Licensed under the MIT License.
+
 from typing import Any
 import json
 import pytest

--- a/ui/README.md
+++ b/ui/README.md
@@ -1,3 +1,5 @@
+<!-- Copyright (c) 2024 LibreAssistant contributors. Licensed under the MIT License. -->
+
 # UI Package
 
 This directory contains standalone web components and the assets needed to style them.


### PR DESCRIPTION
## Summary
- prepend standard MIT license headers across Python, TypeScript, and Markdown files
- update license checker to skip `node_modules` and virtual environments

## Testing
- `python scripts/check_license_headers.py`
- `pytest` *(fails: ModuleNotFoundError: No module named 'pysqlcipher3')*

------
https://chatgpt.com/codex/tasks/task_e_68a64e4661008332990715a0a60c2856