### PR TITLE
Remove unused SimpleNamespace import

### DIFF
--- a/src/libreassistant/providers/local.py
+++ b/src/libreassistant/providers/local.py
@@ -14,7 +14,6 @@ from __future__ import annotations
 from dataclasses import dataclass
 from collections import deque
 from time import monotonic
-from types import SimpleNamespace
 
 
 @dataclass


### PR DESCRIPTION
## Summary
- drop unused SimpleNamespace import from local provider

## Testing
- `ruff check src/libreassistant/providers/local.py`
- `pytest` *(fails: ModuleNotFoundError: No module named 'pysqlcipher3')*

------
https://chatgpt.com/codex/tasks/task_e_68a6517054cc8332bf5d346406d20389