### PR TITLE
Annotate optional database connection

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -20,3 +20,8 @@ ignore_missing_imports = True
 ignore_missing_imports = True
 [mypy-uvicorn.*]
 ignore_missing_imports = True
+
+[mypy-pysqlcipher3]
+ignore_missing_imports = True
+[mypy-pysqlcipher3.*]
+ignore_missing_imports = True

--- a/src/libreassistant/vault.py
+++ b/src/libreassistant/vault.py
@@ -32,6 +32,7 @@ class DataVault:
         key: bytes | None = None,
     ) -> None:
         self._lock = Lock()
+        self._conn: sqlite3.Connection | None = None
 
         # Key management -------------------------------------------------
         self._key_file = Path(key_file) if key_file else None
@@ -60,7 +61,6 @@ class DataVault:
             )
             self._conn.commit()
         else:
-            self._conn = None
             self._data: Dict[str, bytes] = {}
             self._consent: Dict[str, bool] = {}
 


### PR DESCRIPTION
## Summary
- make DataVault's SQLite connection optional by declaring `_conn: sqlite3.Connection | None`
- ignore missing pysqlcipher3 stubs in mypy configuration

## Testing
- `mypy src/libreassistant/vault.py`
- `pytest tests/test_vault.py -q` *(fails: ModuleNotFoundError: No module named 'pysqlcipher3'; build of pysqlcipher3 failed because sqlcipher/sqlite3.h not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a651736a4c833291fe8d2f4f3796db