### PR TITLE
feat: add context manager support to MCP client

### DIFF
--- a/docs/plugin-api.md
+++ b/docs/plugin-api.md
@@ -83,6 +83,20 @@ class EchoPlugin(MCPPluginAdapter):
 The adapter handles JSON‑RPC communication with the TypeScript server and
 returns the tool's JSON response to the microkernel.
 
+Both :class:`MCPPluginAdapter` and the underlying :class:`MCPClient` implement
+the context manager protocol.  When used with ``with`` they ensure that the
+spawned MCP subprocess is terminated automatically:
+
+```python
+from libreassistant.mcp_adapter import MCPClient
+
+with MCPClient("servers/echo/index.ts") as client:
+    client.request("listTools")
+
+with EchoPlugin() as plugin:
+    plugin.run({}, {"message": "hi"})
+```
+
 ## File I/O Plugin Security
 
 The built-in `file_io` plugin exposes basic filesystem operations. It sets

--- a/src/libreassistant/mcp_adapter.py
+++ b/src/libreassistant/mcp_adapter.py
@@ -18,7 +18,17 @@ RUNNER = ROOT / "src" / "mcp" / "server-runner.js"
 
 
 class MCPClient:
-    """Minimal JSON-RPC client speaking to an MCP server over stdio."""
+    """Minimal JSON-RPC client speaking to an MCP server over stdio.
+
+    The client manages a subprocess running an MCP server and provides a
+    blocking ``request`` API.  It implements the context manager protocol so
+    that resources are always released::
+
+        with MCPClient("servers/echo/index.ts") as client:
+            client.request("listTools")
+
+    Exiting the ``with`` block automatically terminates the subprocess.
+    """
 
     def __init__(
         self,
@@ -130,6 +140,25 @@ class MCPClient:
             if getattr(self, "_reader", None) and self._reader.is_alive():
                 self._reader.join(timeout=0.1)
 
+    # -- context manager -------------------------------------------------
+
+    def __enter__(self) -> "MCPClient":
+        """Return ``self`` when entering a ``with`` block."""
+
+        return self
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        tb: object | None,
+    ) -> bool:
+        """Ensure the subprocess is terminated on context exit."""
+
+        self.close()
+        # Propagate any exception that occurred inside the with block.
+        return False
+
 
 Resolver = Callable[[Dict[str, Any]], Tuple[str, Dict[str, Any]]]
 
@@ -150,6 +179,19 @@ class MCPPluginAdapter:
     def close(self) -> None:
         """Release resources held by the underlying MCP client."""
         self.client.close()
+
+    # Allow adapters to be used as context managers for automatic cleanup.
+    def __enter__(self) -> "MCPPluginAdapter":
+        return self
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        tb: object | None,
+    ) -> bool:
+        self.close()
+        return False
 
     def __del__(self) -> None:  # pragma: no cover - best effort cleanup
         try:

--- a/tests/test_mcp_adapter.py
+++ b/tests/test_mcp_adapter.py
@@ -79,6 +79,19 @@ def test_request_times_out():
         client.close()
 
 
+def test_process_terminates_on_context_exit(mock_mcp_server):
+    client = MCPClient.__new__(MCPClient)
+    client.proc = mock_mcp_server
+    client.next_id = 1
+    client.timeout = None
+    _setup_client(client)
+
+    with client:
+        assert client.request("listTools") == {"tools": []}
+
+    assert client.proc.poll() is not None
+
+
 def test_list_tools_mock_server(mock_mcp_server):
     client = MCPClient.__new__(MCPClient)
     client.proc = mock_mcp_server


### PR DESCRIPTION
## Summary
- support context management in `MCPClient` and `MCPPluginAdapter`
- document `MCPClient`/adapter context manager usage
- test that `MCPClient` subprocess terminates when leaving context

## Testing
- `PYTHONPATH=/tmp/stub:src pytest --noconftest tests/test_mcp_adapter.py::test_process_terminates_on_context_exit -q`
- `npm test` *(fails: command hung with experimental loader warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68a65ec5c344833298304d32f030f874