### PR TITLE
Add pysqlcipher3 dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ dependencies = [
     "cryptography",
     "cssutils",
     "httpx",
+    "pysqlcipher3",
 ]
 
 [project.optional-dependencies]

--- a/uv.lock
+++ b/uv.lock
@@ -40,6 +40,8 @@ pydantic==2.11.7
     # via fastapi
 pydantic-core==2.33.2
     # via pydantic
+pysqlcipher3==1.2.0
+    # via libreassistant (pyproject.toml)
 sniffio==1.3.1
     # via anyio
 starlette==0.47.2


### PR DESCRIPTION
## Summary
- add pysqlcipher3 to project dependencies
- regenerate uv.lock

## Testing
- `uv pip compile pyproject.toml -o uv.lock`
- `pytest` *(fails: ModuleNotFoundError: No module named 'fastapi')*


------
https://chatgpt.com/codex/tasks/task_e_68a6631f72508332a0b895cea4c1ae7a