### PR TITLE
Add tests for expert JSON parsing

### DIFF
--- a/tests/test_experts_argumentation.py
+++ b/tests/test_experts_argumentation.py
@@ -1,0 +1,33 @@
+import pytest
+
+from libreassistant.experts import argumentation
+
+
+def test_argumentation_valid_json(monkeypatch):
+    monkeypatch.setattr(
+        argumentation.providers,
+        "generate",
+        lambda provider, prompt: '{"points": ["A", "B", "C"]}',
+    )
+    result = argumentation.analyze("reach the moon")
+    assert result == {"points": ["A", "B", "C"]}
+
+
+def test_argumentation_malformed_json(monkeypatch):
+    monkeypatch.setattr(
+        argumentation.providers,
+        "generate",
+        lambda provider, prompt: "not json",
+    )
+    with pytest.raises(ValueError):
+        argumentation.analyze("goal")
+
+
+def test_argumentation_missing_points(monkeypatch):
+    monkeypatch.setattr(
+        argumentation.providers,
+        "generate",
+        lambda provider, prompt: '{"point": []}',
+    )
+    with pytest.raises(ValueError):
+        argumentation.analyze("goal")

--- a/tests/test_experts_communications.py
+++ b/tests/test_experts_communications.py
@@ -1,0 +1,33 @@
+import pytest
+
+from libreassistant.experts import communications
+
+
+def test_communications_valid_json(monkeypatch):
+    monkeypatch.setattr(
+        communications.providers,
+        "generate",
+        lambda provider, prompt: '{"message": "Stay curious", "audience": "everyone"}',
+    )
+    result = communications.analyze("learn")
+    assert result == {"message": "Stay curious", "audience": "everyone"}
+
+
+def test_communications_malformed_json(monkeypatch):
+    monkeypatch.setattr(
+        communications.providers,
+        "generate",
+        lambda provider, prompt: "<xml>",
+    )
+    with pytest.raises(ValueError):
+        communications.analyze("goal")
+
+
+def test_communications_missing_fields(monkeypatch):
+    monkeypatch.setattr(
+        communications.providers,
+        "generate",
+        lambda provider, prompt: '{"message": "hi"}',
+    )
+    with pytest.raises(ValueError):
+        communications.analyze("goal")


### PR DESCRIPTION
## Summary
- add tests for argumentation expert to validate JSON parsing and error handling
- add tests for communications expert to validate JSON parsing and error handling

## Testing
- `pytest tests/test_experts_argumentation.py tests/test_experts_communications.py`


------
https://chatgpt.com/codex/tasks/task_e_68a6631ce4a0833294113db1a244b7ee