### PR TITLE
refactor: use register approach for ts-node tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "type": "module",
   "scripts": {
-    "test": "node --test --loader ts-node/esm tests/mcp/*.test.ts"
+    "test": "node --test --import ./register-ts-node.js tests/mcp/*.test.ts"
   },
   "dependencies": {
     "ajv": "^8.12.0"

--- a/register-ts-node.js
+++ b/register-ts-node.js
@@ -1,0 +1,4 @@
+import { register } from 'node:module';
+import { pathToFileURL } from 'node:url';
+
+register('ts-node/esm', pathToFileURL('./'));


### PR DESCRIPTION
## Summary
- run Node test runner with `--import ./register-ts-node.js` instead of `--loader ts-node/esm`
- add `register-ts-node.js` to hook ts-node ESM loader via `module.register`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a66d841e248332b783558926a6d886