### PR TITLE
fix: harden path validation

### DIFF
--- a/servers/files/index.ts
+++ b/servers/files/index.ts
@@ -79,7 +79,10 @@ const prompts: PromptSchema[] = [
  */
 function resolve(p: string) {
   const full = path.resolve(baseDir, p);
-  if (!full.startsWith(baseDir)) throw new Error('path outside allowed directory');
+  const relative = path.relative(baseDir, full);
+  if (relative.startsWith('..') || path.isAbsolute(relative)) {
+    throw new Error('path outside allowed directory');
+  }
   return full;
 }
 


### PR DESCRIPTION
## Summary
- use `path.relative` to prevent directory traversal and handle case-insensitive filesystems

## Testing
- `npm test` *(fails: hangs at startup)*

------
https://chatgpt.com/codex/tasks/task_e_68a676453abc83329eac48ba54b8e288