### PR TITLE
Handle ValueError during file path validation

### DIFF
--- a/src/libreassistant/plugins/file_io.py
+++ b/src/libreassistant/plugins/file_io.py
@@ -76,7 +76,11 @@ class FileIOPlugin(MCPPluginAdapter):
             # traversal attacks.
             resolved_path = os.path.realpath(payload["path"])
             base_dir = os.path.realpath(ALLOWED_BASE_DIR)
-            if os.path.commonpath([resolved_path, base_dir]) != base_dir:
+            try:
+                common = os.path.commonpath([resolved_path, base_dir])
+            except ValueError:
+                return {"error": "path outside allowed directory"}
+            if common != base_dir:
                 return {"error": "path outside allowed directory"}
             user_state["last_file_path"] = resolved_path
             payload["path"] = resolved_path

--- a/tests/test_file_io_plugin.py
+++ b/tests/test_file_io_plugin.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import os
 from pathlib import Path
 from typing import Any
 
@@ -75,6 +76,22 @@ def test_file_io_plugin_path_sanitization(tmp_path: Path) -> None:
     result = plugin.run(state, {"operation": "read", "path": str(outside)})
     assert result == {"error": "path outside allowed directory"}
     assert state["last_file_path"] == str(tmp_path / "sanitized.txt")
+
+
+def test_file_io_plugin_handles_commonpath_value_error(
+    tmp_path: Path, monkeypatch
+) -> None:
+    file_io.ALLOWED_BASE_DIR = str(tmp_path)
+    plugin = FileIOPlugin()
+    state: dict[str, Any] = {}
+    path = tmp_path / "file.txt"
+
+    def raise_value_error(paths: list[str]) -> str:
+        raise ValueError("no common path")
+
+    monkeypatch.setattr(os.path, "commonpath", raise_value_error)
+    result = plugin.run(state, {"operation": "read", "path": str(path)})
+    assert result == {"error": "path outside allowed directory"}
 
 
 def test_file_io_plugin_integration(client, tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- ensure file paths outside allowed directory return error even when `os.path.commonpath` raises `ValueError`
- test file I/O plugin's behavior when `os.path.commonpath` raises `ValueError`

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a6765dffac8332963dc83d21cd3455