### PR TITLE
Return structured error for unknown plugins

### DIFF
--- a/src/libreassistant/kernel.py
+++ b/src/libreassistant/kernel.py
@@ -42,7 +42,7 @@ class Microkernel:
         """Invoke a registered plugin for the given user."""
         plugin = self._plugins.get(name)
         if plugin is None:
-            raise KeyError(name)
+            return {"error": "unknown_plugin", "plugin": name}
         state = self.get_state(user_id)
         model = getattr(plugin, "InputModel", None)
         if isinstance(model, type) and issubclass(model, BaseModel):

--- a/src/libreassistant/main.py
+++ b/src/libreassistant/main.py
@@ -127,14 +127,11 @@ def create_app() -> FastAPI:
     @app.post("/api/v1/invoke")
     def invoke(request: InvokeRequest) -> Dict[str, Any]:
         """Invoke a registered plugin through the microkernel."""
-        try:
-            result = kernel.invoke(
-                request.plugin, request.user_id, request.payload
-            )
-        except KeyError as exc:  # pragma: no cover - error branch
-            raise HTTPException(
-                status_code=404, detail="Plugin not found"
-            ) from exc
+        result = kernel.invoke(
+            request.plugin, request.user_id, request.payload
+        )
+        if result.get("error") == "unknown_plugin":
+            raise HTTPException(status_code=404, detail="Plugin not found")
         state = kernel.get_state(request.user_id)
         db.add_history(
             request.user_id, request.plugin, request.payload, request.granted

--- a/tests/test_kernel.py
+++ b/tests/test_kernel.py
@@ -5,8 +5,6 @@
 
 from __future__ import annotations
 
-import pytest
-
 from libreassistant.kernel import Microkernel
 
 
@@ -35,10 +33,10 @@ def test_get_state_returns_same_dict() -> None:
     assert second["x"] == 1
 
 
-def test_invoke_missing_plugin_raises() -> None:
+def test_invoke_missing_plugin_returns_error() -> None:
     kernel = Microkernel()
-    with pytest.raises(KeyError):
-        kernel.invoke("missing", "user", {})
+    result = kernel.invoke("missing", "user", {})
+    assert result == {"error": "unknown_plugin", "plugin": "missing"}
 
 
 def test_reset_clears_plugins_and_state() -> None:
@@ -47,5 +45,7 @@ def test_reset_clears_plugins_and_state() -> None:
     kernel.invoke("echo", "user", {"msg": "hi"})
     kernel.reset()
     assert kernel.get_state("user") == {"user_id": "user"}
-    with pytest.raises(KeyError):
-        kernel.invoke("echo", "user", {"msg": "hi"})
+    assert kernel.invoke("echo", "user", {"msg": "hi"}) == {
+        "error": "unknown_plugin",
+        "plugin": "echo",
+    }


### PR DESCRIPTION
## Summary
- Return structured error payload when invoking an unregistered plugin
- Propagate unknown plugin errors to HTTP 404 responses in the API
- Update kernel tests to assert new error behavior

## Testing
- `pytest`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a68d5fb5b48332b16e2ebd3c5e6b40