### PR TITLE
docs: mention cross-drive path handling for file I/O plugin

### DIFF
--- a/docs/file_io_plugin.md
+++ b/docs/file_io_plugin.md
@@ -57,6 +57,6 @@ curl -X POST http://localhost:8000/api/v1/invoke \
 
 ## Security Considerations
 
-- Access is limited to the `~/desktop` directory via `ALLOWED_BASE_DIR` and validated with `os.path.realpath` to prevent path traversal.
+- Access is limited to the `~/desktop` directory via `ALLOWED_BASE_DIR` and validated with `os.path.realpath` and `os.path.commonpath` to prevent path traversal. Cross-drive paths that cannot be compared are rejected.
 - Destructive operations (`update`, `delete`) require an explicit `confirm` flag.
 - Each operation is logged with `db.add_file_audit` for accountability.

--- a/docs/plugin-api.md
+++ b/docs/plugin-api.md
@@ -105,6 +105,7 @@ the MCP file server through `MCP_FS_BASE_DIR`.
 
 Before any operation, the plugin normalizes user supplied paths with
 `os.path.realpath` and verifies that the result remains within
-`ALLOWED_BASE_DIR`. Requests that resolve outside this directory are rejected,
-preventing path traversal and confining access to an explicitly approved
-workspace.
+`ALLOWED_BASE_DIR`. The check uses `os.path.commonpath`; if it raises
+`ValueError` (for example, on cross-drive inputs) or the common path differs,
+the request is rejected. This prevents path traversal and confines access to an
+explicitly approved workspace.

--- a/src/libreassistant/plugins/file_io.py
+++ b/src/libreassistant/plugins/file_io.py
@@ -73,10 +73,12 @@ class FileIOPlugin(MCPPluginAdapter):
             # Resolve the path to its canonical form and ensure it remains
             # within the allowed base directory. The resolved path is stored
             # in ``user_state`` and passed on to the server to prevent path
-            # traversal attacks.
+            # traversal attacks. ``os.path.commonpath`` raises ``ValueError``
+            # for paths on different drives; such requests are rejected.
             resolved_path = os.path.realpath(payload["path"])
             base_dir = os.path.realpath(ALLOWED_BASE_DIR)
             try:
+                # ``commonpath`` may raise ``ValueError`` on cross-drive inputs
                 common = os.path.commonpath([resolved_path, base_dir])
             except ValueError:
                 return {"error": "path outside allowed directory"}


### PR DESCRIPTION
## Summary
- note that `os.path.commonpath` can raise a `ValueError` for cross-drive paths and reject such requests
- document cross-drive path rejection in File I/O plugin docs

## Testing
- `pytest tests/test_file_io_plugin.py::test_file_io_plugin_handles_commonpath_value_error -q`


------
https://chatgpt.com/codex/tasks/task_e_68a68d8d654483329534edc4e625a70a