### PR TITLE
docs: add blank lines around fences

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -144,6 +144,7 @@ LibreAssistant exposes a FastAPI service with endpoints for plugin invocation, u
   - `400` if `consent` field missing.
 
 - `GET /api/v1/consent/{user_id}` – get consent status
+
   ```bash
   curl http://localhost:8000/api/v1/consent/alice
   ```

--- a/docs/data-vault.md
+++ b/docs/data-vault.md
@@ -36,4 +36,3 @@ application process.
   accesses and deletions.
 - **Export & Deletion** – users may export or purge their data, supporting data
   portability and the right to be forgotten.
-

--- a/docs/law_api.md
+++ b/docs/law_api.md
@@ -36,8 +36,7 @@ array so requests can be traced back to their origins.
     "query": "education",
     "source": "govinfo",
     "output_format": "md",
-    "output_path": "law"
+  "output_path": "law"
   }
 }
 ```
-


### PR DESCRIPTION
## Summary
- ensure consent endpoint example is separated by blank lines
- remove stray trailing blank lines in docs

## Testing
- `npx -y markdownlint-cli docs/api.md docs/data-vault.md docs/law_api.md`
- `node --test --import ./register-ts-node.js tests/mcp/*.test.ts` (experimental warnings)
- `pytest` *(fails: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_68a694ee6d94833292e4029f09a4fb29