### PR TITLE
Implement database connection teardown

### DIFF
--- a/src/libreassistant/db.py
+++ b/src/libreassistant/db.py
@@ -48,6 +48,14 @@ def get_conn() -> sqlite3.Connection:
     return _conn
 
 
+def close_conn() -> None:
+    """Close the global database connection if it exists."""
+    global _conn
+    if _conn is not None:
+        _conn.close()
+        _conn = None
+
+
 def _initialize(conn: sqlite3.Connection) -> None:
     """Create required tables and indexes in the database.
 

--- a/src/libreassistant/kernel.py
+++ b/src/libreassistant/kernel.py
@@ -9,6 +9,8 @@ from typing import Any, Dict, Protocol, cast
 
 from pydantic import BaseModel, ValidationError
 
+from . import db
+
 
 class Plugin(Protocol):
     """Protocol that all plugins must implement."""
@@ -67,6 +69,7 @@ class Microkernel:
                     close()
                 except Exception:  # pragma: no cover - best effort cleanup
                     pass
+        db.close_conn()
 
 
 kernel = Microkernel()

--- a/src/libreassistant/main.py
+++ b/src/libreassistant/main.py
@@ -32,6 +32,7 @@ def create_app() -> FastAPI:
     async def lifespan(_: FastAPI):
         yield
         kernel.shutdown()
+        db.close_conn()
 
     app = FastAPI(title="LibreAssistant", lifespan=lifespan)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -69,3 +69,4 @@ def reset_kernel() -> Generator[None, None, None]:
     providers.register("local", LocalProvider())
     app_db.clear()
     yield
+    app_db.close_conn()

--- a/tests/test_db_connection_cycle.py
+++ b/tests/test_db_connection_cycle.py
@@ -1,0 +1,17 @@
+# Copyright (c) 2024 LibreAssistant contributors.
+# Licensed under the MIT License.
+
+"""Tests for repeatedly opening and closing the database connection."""
+
+from libreassistant import db
+
+
+def test_get_close_reopen_cycles() -> None:
+    conn1 = db.get_conn()
+    db.close_conn()
+    conn2 = db.get_conn()
+    assert conn2 is not conn1
+    db.close_conn()
+    conn3 = db.get_conn()
+    assert conn3 is not conn2
+    db.close_conn()


### PR DESCRIPTION
## Summary
- Add `close_conn` helper to reset and close global DB connection
- Ensure shutdown and test teardown close the database
- Test repeated `get_conn`/`close_conn` cycles

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a6a1518a28833291cd71d13f1c2399