### PR TITLE
feat: dynamically load MCP plugins

### DIFF
--- a/src/switchboard/mcpAdapter.ts
+++ b/src/switchboard/mcpAdapter.ts
@@ -4,31 +4,49 @@
 /**
  * Switchboard adapter that exposes MCP servers as high level "plugins".
  *
- * A static mapping translates plugin identifiers to MCP tool names. Destructive
- * file operations will trigger a user consent modal before execution, and every
+ * On initialization it loads `config/mcp.registry.json` and registers the
+ * listed servers with an {@link MCPClient}. Each tool provided by the servers
+ * is exposed under a plugin identifier `server.tool`. Destructive file
+ * operations will trigger a user consent modal before execution, and every
  * invocation is recorded in the user's history log via HTTP.
  */
+import path from 'path';
 import { MCPClient } from '../mcp/client.js';
+import { loadRegistry } from '../mcp/registry.js';
+
+type ToolEntry = { server: string; tool: string };
 
 export class MCPAdapter {
-  private toolMap: Record<string, string | ((params: any) => string)> = {
-    echo: 'echo_message',
-    files: (params: any) => {
-      const op = params?.operation;
-      const mapping: Record<string, string> = {
-        read: 'fs_read',
-        create: 'fs_create',
-        update: 'fs_update',
-        delete: 'fs_delete',
-        list: 'fs_list',
-      };
-      return mapping[op];
-    },
-    law_by_keystone: 'generate_legal_summary',
-    think_tank: 'analyze_goal',
-  };
+  private toolMap: Record<string, ToolEntry> = {};
 
-  constructor(private client: MCPClient) {}
+  private constructor(private client: MCPClient) {}
+
+  /**
+   * Load the MCP registry and build the tool mapping.
+   * @param client MCP client instance used for registration
+   * @returns Initialized {@link MCPAdapter} instance
+   */
+  static async create(client: MCPClient) {
+    const adapter = new MCPAdapter(client);
+    await adapter.initialize();
+    return adapter;
+  }
+
+  /**
+   * Register servers declared in the registry and cache their tools.
+   * @sideeffect Spawns MCP server processes and populates `toolMap`
+   */
+  private async initialize() {
+    const registryPath = path.resolve('config/mcp.registry.json');
+    await loadRegistry(registryPath, this.client);
+    for (const serverName of this.client.listServers()) {
+      const server = this.client.getServer(serverName);
+      for (const tool of server.listTools()) {
+        const key = `${serverName}.${tool.name}`;
+        this.toolMap[key] = { server: serverName, tool: tool.name };
+      }
+    }
+  }
 
   /**
    * Returns the identifiers of all available plugins.
@@ -45,22 +63,21 @@ export class MCPAdapter {
    * Destructive file operations prompt the user for consent and each
    * invocation is persisted to the user's history log.
    *
-   * @param plugin - Plugin identifier to execute.
+   * @param plugin - Plugin identifier to execute (format: server.tool).
    * @param params - Parameters forwarded to the underlying tool.
    * @param userId - User performing the action.
    * @returns Result from the MCP client.
    * @sideeffect May display a consent modal and log invocation history via HTTP.
    */
   async invokePlugin(plugin: string, params: any, userId: string): Promise<any> {
-    const mapping = this.toolMap[plugin];
-    if (!mapping) throw new Error(`Unknown plugin ${plugin}`);
-    const tool = typeof mapping === 'function' ? mapping(params) : mapping;
-    if (!tool) throw new Error(`Unknown operation for plugin ${plugin}`);
+    const entry = this.toolMap[plugin];
+    if (!entry) throw new Error(`Unknown plugin ${plugin}`);
+    const { server, tool } = entry;
 
     let granted = true;
     // Prompt for confirmation on destructive file operations
     if (
-      plugin === 'files' &&
+      server === 'files' &&
       (tool === 'fs_update' || tool === 'fs_delete') &&
       !params.confirm
     ) {
@@ -75,7 +92,7 @@ export class MCPAdapter {
       }
     }
 
-    const result = await this.client.invoke(plugin, tool, params);
+    const result = await this.client.invoke(server, tool, params);
     await this.recordHistory(userId, plugin, params, granted);
     return result;
   }

--- a/tests/mcp/adapter.test.ts
+++ b/tests/mcp/adapter.test.ts
@@ -1,23 +1,41 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 import { MCPAdapter } from '../../src/switchboard/mcpAdapter.js';
+import { MCPClient } from '../../src/mcp/client.js';
 
-class MockClient {
+class RecordingClient extends MCPClient {
   public invokes: any[] = [];
-  async invoke(plugin: string, tool: string, params: any): Promise<any> {
-    this.invokes.push({ plugin, tool, params });
-    return { plugin, tool, params };
+  async invoke(server: string, tool: string, params: any): Promise<any> {
+    this.invokes.push({ server, tool, params });
+    return super.invoke(server, tool, params);
   }
 }
 
-test('listPlugins exposes available plugin identifiers', () => {
-  const adapter = new MCPAdapter(new MockClient() as any);
-  assert.deepEqual(adapter.listPlugins().sort(), ['echo', 'files', 'law_by_keystone', 'think_tank']);
+test('listPlugins exposes available plugin identifiers', async () => {
+  const client = new RecordingClient();
+  const adapter = await MCPAdapter.create(client);
+  try {
+    assert.deepEqual(
+      adapter.listPlugins().sort(),
+      [
+        'echo.echo_message',
+        'files.fs_create',
+        'files.fs_delete',
+        'files.fs_list',
+        'files.fs_read',
+        'files.fs_update',
+        'law_by_keystone.generate_legal_summary',
+        'think_tank.analyze_goal',
+      ],
+    );
+  } finally {
+    await client.close();
+  }
 });
 
 test('invokePlugin maps plugin names and logs history', async () => {
-  const client = new MockClient();
-  const adapter = new MCPAdapter(client as any);
+  const client = new RecordingClient();
+  const adapter = await MCPAdapter.create(client);
   const calls: any[] = [];
   const originalFetch = globalThis.fetch;
   globalThis.fetch = async (url: any, init: any) => {
@@ -25,24 +43,25 @@ test('invokePlugin maps plugin names and logs history', async () => {
     return { ok: true } as any;
   };
   try {
-    await adapter.invokePlugin('echo', { message: 'hi' }, 'u1');
+    await adapter.invokePlugin('echo.echo_message', { message: 'hi' }, 'u1');
     assert.deepEqual(client.invokes, [
-      { plugin: 'echo', tool: 'echo_message', params: { message: 'hi' } },
+      { server: 'echo', tool: 'echo_message', params: { message: 'hi' } },
     ]);
     assert.equal(calls.length, 1);
     assert.equal(calls[0].url, '/api/v1/history/u1');
     const body = JSON.parse(calls[0].init.body);
-    assert.equal(body.plugin, 'echo');
+    assert.equal(body.plugin, 'echo.echo_message');
     assert.deepEqual(body.payload, { message: 'hi' });
     assert.equal(body.granted, true);
   } finally {
     globalThis.fetch = originalFetch;
+    await client.close();
   }
 });
 
 test('destructive file operations require consent and log outcome', async () => {
-  const client = new MockClient();
-  const adapter = new MCPAdapter(client as any);
+  const client = new RecordingClient();
+  const adapter = await MCPAdapter.create(client);
   const history: any[] = [];
   const originalFetch = globalThis.fetch;
   const originalConsent = (globalThis as any).showConsentModal;
@@ -57,9 +76,13 @@ test('destructive file operations require consent and log outcome', async () => 
   };
   try {
     // consent granted
-    await adapter.invokePlugin('files', { operation: 'update', path: '/tmp/a' }, 'u2');
+    await adapter.invokePlugin('files.fs_update', { path: 'a.txt', content: '' }, 'u2');
     assert.deepEqual(client.invokes, [
-      { plugin: 'files', tool: 'fs_update', params: { operation: 'update', path: '/tmp/a', confirm: true } },
+      {
+        server: 'files',
+        tool: 'fs_update',
+        params: { path: 'a.txt', content: '', confirm: true },
+      },
     ]);
     assert.equal(consentCalls, 1);
     let body = JSON.parse(history[0].init.body);
@@ -70,16 +93,17 @@ test('destructive file operations require consent and log outcome', async () => 
       consentCalls++;
       return false;
     };
-    const result = await adapter.invokePlugin('files', { operation: 'delete', path: '/tmp/b' }, 'u2');
+    const result = await adapter.invokePlugin('files.fs_delete', { path: 'b.txt' }, 'u2');
     assert.deepEqual(result, { error: 'PermissionDenied' });
     assert.equal(client.invokes.length, 1); // no new invoke
     assert.equal(consentCalls, 2);
     body = JSON.parse(history[1].init.body);
-    assert.equal(body.plugin, 'files');
-    assert.equal(body.payload.path, '/tmp/b');
+    assert.equal(body.plugin, 'files.fs_delete');
+    assert.equal(body.payload.path, 'b.txt');
     assert.equal(body.granted, false);
   } finally {
     globalThis.fetch = originalFetch;
     (globalThis as any).showConsentModal = originalConsent;
+    await client.close();
   }
 });


### PR DESCRIPTION
## Summary
- load `config/mcp.registry.json` when creating `MCPAdapter`
- build plugin map from registered servers' `listTools()` responses
- expose plugins using `server.tool` identifiers and keep consent/audit logging

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a6b34ffc588332b1733ad77a7dbba4