### PR TITLE
Handle plugin errors before logging

### DIFF
--- a/src/libreassistant/main.py
+++ b/src/libreassistant/main.py
@@ -133,6 +133,8 @@ def create_app() -> FastAPI:
         )
         if result.get("error") == "unknown_plugin":
             raise HTTPException(status_code=404, detail="Plugin not found")
+        if "error" in result:
+            raise HTTPException(status_code=400, detail=result["error"])
         state = kernel.get_state(request.user_id)
         db.add_history(
             request.user_id, request.plugin, request.payload, request.granted

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -6,6 +6,7 @@
 from __future__ import annotations
 
 from libreassistant.kernel import kernel
+from pydantic import BaseModel
 
 
 def test_read_root(client) -> None:
@@ -32,3 +33,28 @@ def test_user_state_persists(client) -> None:
     assert first.json()["result"] == {"count": 1}
     assert second.json()["result"] == {"count": 2}
     assert second.json()["state"]["count"] == 2
+
+
+def test_invoke_invalid_payload_returns_400(client) -> None:
+    class RequiredFieldPlugin:
+        class InputModel(BaseModel):
+            value: int
+
+        def run(self, state, payload):
+            return payload
+
+    kernel.register_plugin("required", RequiredFieldPlugin())
+    response = client.post(
+        "/api/v1/invoke",
+        json={"plugin": "required", "payload": {}, "user_id": "alice"},
+    )
+    assert response.status_code == 400
+
+
+def test_unknown_plugin_returns_404(client) -> None:
+    response = client.post(
+        "/api/v1/invoke",
+        json={"plugin": "missing", "payload": {}, "user_id": "alice"},
+    )
+    assert response.status_code == 404
+    assert response.json()["detail"] == "Plugin not found"


### PR DESCRIPTION
## Summary
- Raise 400 responses when a plugin returns an error and skip history logging
- Keep 404 for unknown plugin names
- Test invalid payloads produce 400 and unknown plugins produce 404

## Testing
- `pytest tests/test_main.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a734c1773483328d08b3d02a689414