### PR TITLE
Add caching and filtering for transparency BOM

### DIFF
--- a/src/libreassistant/transparency.py
+++ b/src/libreassistant/transparency.py
@@ -9,9 +9,21 @@ import os
 import time
 from collections import deque
 from pathlib import Path
-from typing import Any, Deque, Dict, List
+from typing import Any, Deque, Dict, List, Set
 
 import importlib.metadata
+
+try:  # Python 3.11+
+    import tomllib
+except ModuleNotFoundError:  # pragma: no cover - fallback for older versions
+    tomllib = None  # type: ignore
+
+
+# Module-level caches to avoid repeated scanning
+_DEPENDENCIES: List[str] | None = None
+_MODELS_CACHE: Dict[Path, List[str]] = {}
+_DATASETS_CACHE: Dict[Path, List[str]] = {}
+_PYPROJECT_PACKAGES: Set[str] | None = None
 
 
 class HealthMonitor:
@@ -44,32 +56,74 @@ class HealthMonitor:
         }
 
 
+def _load_pyproject_packages() -> Set[str]:
+    """Load package names declared in pyproject.toml."""
+    global _PYPROJECT_PACKAGES
+    if _PYPROJECT_PACKAGES is not None:
+        return _PYPROJECT_PACKAGES
+    if tomllib is None:  # pragma: no cover - Python <3.11 without tomli
+        _PYPROJECT_PACKAGES = set()
+        return _PYPROJECT_PACKAGES
+    project_root = Path(__file__).resolve().parents[2]
+    pyproject_path = project_root / "pyproject.toml"
+    if not pyproject_path.exists():  # pragma: no cover - missing file
+        _PYPROJECT_PACKAGES = set()
+        return _PYPROJECT_PACKAGES
+    try:
+        data = tomllib.loads(pyproject_path.read_text())
+    except Exception:  # pragma: no cover - malformed file
+        _PYPROJECT_PACKAGES = set()
+        return _PYPROJECT_PACKAGES
+    project = data.get("project", {})
+    deps = list(project.get("dependencies", []))
+    opt = project.get("optional-dependencies", {})
+    for group in opt.values():
+        deps.extend(group)
+    names: Set[str] = set()
+    for dep in deps:
+        name = dep.split()[0].split("[")[0].lower()
+        names.add(name)
+    _PYPROJECT_PACKAGES = names
+    return _PYPROJECT_PACKAGES
+
+
+def _scan(path: Path) -> List[str]:
+    """Return sorted non-hidden entries for the given path."""
+    if not path.exists():
+        return []
+    if path.is_file():
+        return [path.name]
+    items = [
+        p.name
+        for p in path.iterdir()
+        if (p.is_file() or p.is_dir()) and not p.name.startswith(".")
+    ]
+    return sorted(items)
+
+
 def get_bill_of_materials() -> Dict[str, List[str]]:
     """Gather a list of installed dependencies, models, and datasets."""
-    dependencies = sorted(
-        f"{dist.metadata['Name']}=={dist.version}"
-        for dist in importlib.metadata.distributions()
-    )
+    global _DEPENDENCIES, _MODELS_CACHE, _DATASETS_CACHE
+
+    if _DEPENDENCIES is None:
+        declared = _load_pyproject_packages()
+        deps = [
+            f"{dist.metadata['Name']}=={dist.version}"
+            for dist in importlib.metadata.distributions()
+            if not declared or dist.metadata['Name'].lower() in declared
+        ]
+        _DEPENDENCIES = sorted(deps)
+
     models_dir = Path(os.environ.get("LA_MODELS_DIR", "models"))
     datasets_dir = Path(os.environ.get("LA_DATASETS_DIR", "datasets"))
 
-    def _scan(path: Path) -> List[str]:
-        if not path.exists():
-            return []
-        if path.is_file():
-            return [path.name]
-        items = [
-            p.name
-            for p in path.iterdir()
-            if (p.is_file() or p.is_dir()) and not p.name.startswith(".")
-        ]
-        return sorted(items)
-
-    models = _scan(models_dir)
-    datasets = _scan(datasets_dir)
+    if models_dir not in _MODELS_CACHE:
+        _MODELS_CACHE[models_dir] = _scan(models_dir)
+    if datasets_dir not in _DATASETS_CACHE:
+        _DATASETS_CACHE[datasets_dir] = _scan(datasets_dir)
 
     return {
-        "dependencies": dependencies,
-        "models": models,
-        "datasets": datasets,
+        "dependencies": _DEPENDENCIES,
+        "models": _MODELS_CACHE[models_dir],
+        "datasets": _DATASETS_CACHE[datasets_dir],
     }

--- a/tests/test_transparency.py
+++ b/tests/test_transparency.py
@@ -59,6 +59,44 @@ def test_bom_handles_empty_dirs(client, tmp_path, monkeypatch):
     assert data["datasets"] == []
 
 
+def test_bom_caches_results(monkeypatch, tmp_path):
+    from libreassistant import transparency
+
+    models_dir = tmp_path / "models"
+    datasets_dir = tmp_path / "datasets"
+    models_dir.mkdir()
+    datasets_dir.mkdir()
+    monkeypatch.setenv("LA_MODELS_DIR", str(models_dir))
+    monkeypatch.setenv("LA_DATASETS_DIR", str(datasets_dir))
+
+    calls = {"dist": 0, "scan": 0}
+
+    def fake_distributions():
+        calls["dist"] += 1
+        return []
+
+    def counting_scan(path):
+        calls["scan"] += 1
+        return []
+
+    monkeypatch.setattr(transparency.importlib.metadata, "distributions", fake_distributions)
+    monkeypatch.setattr(transparency, "_scan", counting_scan)
+
+    transparency._DEPENDENCIES = None
+    transparency._MODELS_CACHE.clear()
+    transparency._DATASETS_CACHE.clear()
+
+    transparency.get_bill_of_materials()
+    transparency.get_bill_of_materials()
+
+    assert calls["dist"] == 1
+    assert calls["scan"] == 2
+
+    transparency._DEPENDENCIES = None
+    transparency._MODELS_CACHE.clear()
+    transparency._DATASETS_CACHE.clear()
+
+
 def test_health_reports_metrics(client):
     first = client.get("/api/v1/health").json()["requests"]
     client.get("/")


### PR DESCRIPTION
## Summary
- cache dependencies, models, and datasets for bill of materials
- filter dependency list using packages declared in pyproject
- test BOM caching behavior

## Testing
- `pytest tests/test_transparency.py`

------
https://chatgpt.com/codex/tasks/task_e_68a734e674f483329cba01a699f62f29