### PR TITLE
Align file path plugin test with allowlist

### DIFF
--- a/tests/test_file_io_plugin.py
+++ b/tests/test_file_io_plugin.py
@@ -127,10 +127,8 @@ def test_file_io_plugin_integration(client, tmp_path: Path) -> None:
             "user_id": "alice",
         },
     )
-    assert response.status_code == 200
-    assert response.json()["result"] == {
-        "error": "path outside allowed directory"
-    }
+    assert response.status_code == 400
+    assert response.json() == {"detail": "path outside allowed directory"}
 
     response = client.post(
         "/api/v1/invoke",


### PR DESCRIPTION
## Summary
- Expect HTTP 400 when file path falls outside plugin's allowed directory

## Testing
- `pytest tests/test_file_io_plugin.py::test_file_io_plugin_integration -q`

------
https://chatgpt.com/codex/tasks/task_e_68a8123db90c8332b6023ab751ad3f7b